### PR TITLE
docs: update readme to address script tag error for widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ export default function RootLayout({
     <html lang="en">
       <head>
         {/* add The Context Company widget */}
-        <Script {/* from next/script */}
+        <Script
           crossOrigin="anonymous"
           src="//unpkg.com/@contextcompany/widget/dist/auto.global.js"
         />


### PR DESCRIPTION
I received this error after pasting the script tag from the readme:

```zsh
Synchronous scripts should not be used. See: https://nextjs.org/docs/messages/no-sync-scripts [@next/next/no-sync-scripts]
```

The proposed fix is to either add the `defer` or `async` attribute to the normal script tag, but it's recommended to use `Script` from `next/script`.

Here is some relative documentation: https://nextjs.org/docs/messages/no-sync-scripts