### PR TITLE
chore(package.json): add packageManager field

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,5 +4,6 @@
   "private": true,
   "dependencies": {
     "@changesets/cli": "^2.29.7"
-  }
+  },
+  "packageManager": "pnpm@10.8.1"
 }


### PR DESCRIPTION
I noticed the `packageManager` field was missing as I was prompted with this error below after trying to run `pnpm dev`:

```bash
! The local project doesn't define a 'packageManager' field. Corepack will now add one referencing pnpm@10.8.1+sha512.c50088ba998c67b8ca8c99df8a5e02fd2ae2e2b29aaf238feaa9e124248d3f48f9fb6db2424949ff901cffbb5e0f0cc1ad6aedb602cd29450751d11c35023677.
! For more details about this field, consult the documentation at https://nodejs.org/api/packages.html#packagemanager
```

Didn't include the SHA string inside the field, seems to work fine without it. I referenced the [react-scan](https://github.com/aidenybai/react-scan/blob/main/package.json) package.json for this.