### PR TITLE
feat(widget): fix widget disappearing when dir="rtl"

### DIFF
--- a/packages/widget/src/components/context-menu.tsx
+++ b/packages/widget/src/components/context-menu.tsx
@@ -66,6 +66,7 @@ export default function ContextMenu({
   const menuContent = visibleSignal.value && (
     <div
       ref={menuRef}
+      dir="ltr"
       id="tcc-context-menu"
       className={cn(
         "fixed z-500",

--- a/packages/widget/src/components/draggable.tsx
+++ b/packages/widget/src/components/draggable.tsx
@@ -300,8 +300,9 @@ export function Draggable({
   return (
     <div
       ref={containerRef}
+      dir="ltr"
       className={cn(
-        "fixed inset-0 z-[1000]",
+        "fixed z-[1000]",
         widgetDockedSignal.value === null && "rounded-full",
         widgetDockedSignal.value === "top" && "rounded-b-lg",
         widgetDockedSignal.value === "bottom" && "rounded-t-lg",
@@ -318,6 +319,8 @@ export function Draggable({
         className
       )}
       style={{
+        top: 0,
+        left: 0,
         width: `${dimensionsSignal.value.width}px`,
         height: `${dimensionsSignal.value.height}px`,
       }}

--- a/packages/widget/src/components/dropdown.tsx
+++ b/packages/widget/src/components/dropdown.tsx
@@ -98,6 +98,7 @@ export default function Dropdown({
   const menuContent = visibleSignal.value && (
     <div
       ref={menuRef}
+      dir="ltr"
       id="tcc-dropdown-menu"
       className={cn(
         "fixed z-500",

--- a/packages/widget/src/components/popover/popover.tsx
+++ b/packages/widget/src/components/popover/popover.tsx
@@ -160,8 +160,9 @@ function Popover() {
   return (
     <div
       ref={containerRef}
+      dir="ltr"
       className={cn(
-        "fixed inset-0",
+        "fixed",
         "bg-white border border-gray-200 rounded-lg",
         "z-50 overflow-hidden",
         "flex flex-col",
@@ -169,6 +170,8 @@ function Popover() {
         "animate-fade-in"
       )}
       style={{
+        top: 0,
+        left: 0,
         width: `${popoverDimensionSignal.value.width}px`,
         height: `${popoverDimensionSignal.value.height}px`,
       }}


### PR DESCRIPTION
Force LTR direction on widget-related components and fix positioning to work correctly when parent document uses RTL direction (e.g., `dir='rtl'` for `fa-IR` locale).

> Tested locally by running `pnpm dev:all` and using the `localhost:3001` script tag.
> Closes #8

before:

https://github.com/user-attachments/assets/71da8ec6-6e02-4b7c-a41a-7a7d5f03b6c5

after:

https://github.com/user-attachments/assets/06ff0c85-63c5-447f-9a79-893e6196374d

