### PR TITLE
Added error logging to silent error catches 

### DIFF
--- a/packages/otel/src/nextjs/local/ws.ts
+++ b/packages/otel/src/nextjs/local/ws.ts
@@ -78,7 +78,12 @@ export const startWebSocketServer = async () => {
       try {
         const event = JSON.parse(data.toString());
         captureAnonymousEvent(event);
-      } catch (error) {}
+      } catch (error) {
+        const errorMsg = error instanceof Error ? error.message : String(error);
+        const dataStr = data.toString();
+        const truncatedData = dataStr.length > 200 ? dataStr.slice(0, 200) + "..." : dataStr;
+        debug(`Failed to parse WebSocket message: ${errorMsg}. Data: ${truncatedData}`);
+      }
     });
 
     // subscribe to new items

--- a/packages/widget/src/utils/store.ts
+++ b/packages/widget/src/utils/store.ts
@@ -1,6 +1,12 @@
 import { EnrichedUIRun, EnrichedUIStep, UIStep, UIToolCall } from "@/types";
 import { NewItems, TCCStore } from "../hooks/useSyncTCCStore";
 
+function debugLog(message: string) {
+  if ((window as any).TCC_DEBUG) {
+    console.log(`[TCC] ${message}`);
+  }
+}
+
 export const reconcileStore = (
   prev: TCCStore,
   newItems: NewItems
@@ -101,6 +107,9 @@ export const getUserPromptFromPromptAttribute = (prompt: string): string => {
     }
     return prompt;
   } catch (error) {
+    const errorMsg = error instanceof Error ? error.message : String(error);
+    const truncatedPrompt = prompt.length > 100 ? prompt.slice(0, 100) + "..." : prompt;
+    debugLog(`Failed to extract prompt from attribute: ${errorMsg}. Value: ${truncatedPrompt}`);
     return prompt;
   }
 };

--- a/packages/widget/src/utils/time.ts
+++ b/packages/widget/src/utils/time.ts
@@ -4,6 +4,12 @@ function isValidDateString(maybeDateString: string): boolean {
   return regex.test(maybeDateString);
 }
 
+function debugLog(message: string) {
+  if ((window as any).TCC_DEBUG) {
+    console.log(`[TCC] ${message}`);
+  }
+}
+
 export const recursivelyInjectDateFields = (fields: unknown): unknown => {
   if (Array.isArray(fields)) {
     return fields.map((item) => recursivelyInjectDateFields(item));
@@ -13,7 +19,9 @@ export const recursivelyInjectDateFields = (fields: unknown): unknown => {
       if (typeof value === "string" && isValidDateString(value)) {
         try {
           newFields[key] = new Date(value);
-        } catch {
+        } catch (error) {
+          const errorMsg = error instanceof Error ? error.message : String(error);
+          debugLog(`Failed to parse date string "${value}": ${errorMsg}`);
           newFields[key] = value;
         }
       } else {


### PR DESCRIPTION
   -> webSocket message parsing: log JSON parse errors with truncated data
   -> date field conversion: log failed Date parsing attempts
   -> prompt extraction : log failed JSON parse on prompt attributes
   All errors log when TCC_DEBUG is enabled, improving observability for developers using Observatory.