### PR TITLE
Feat: add escape key close popover

### DIFF
--- a/packages/ts/widget/src/components/popover/popover.tsx
+++ b/packages/ts/widget/src/components/popover/popover.tsx
@@ -162,6 +162,10 @@ function Popover() {
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.key === "Escape") {
         widgetExpandedSignal.value = false;
+        captureAnonymousEvent({
+          event: "widget_expand_event",
+          action: "close",
+        })
       }
     };
     document.addEventListener("keydown", handleKeyDown);


### PR DESCRIPTION
## Summary
Add keyboard shortcut (Escape) to close the popover, following standard UI conventions.

## Changes
- Added `keydown` event listener in `popover.tsx`
- Popover closes when user presses Escape key

## Preview

https://github.com/user-attachments/assets/9a52fe2a-2e9d-47f9-a400-64f374c8b738



## Issues
- Closes #23 