### PR TITLE
fix(python): fix release workflow errors

### DIFF
--- a/packages/python/CHANGELOG.md
+++ b/packages/python/CHANGELOG.md
@@ -1,0 +1,1 @@
+# Changelog

--- a/packages/python/pyproject.toml
+++ b/packages/python/pyproject.toml
@@ -44,7 +44,6 @@ branch = "main"
 tag_format = "python-v{version}"
 commit_message = "chore(python-release): {version}"
 major_on_zero = false
-build_command = "python -m build"
 commit_parser = "scope_parser:PythonScopeParser"
 version_toml = ["pyproject.toml:project.version"]
 version_variables = ["contextcompany/__init__.py:__version__"]
@@ -56,7 +55,7 @@ patch_tags = ["fix", "perf"]
 
 [tool.semantic_release.remote]
 type = "github"
-token = { env = "GH_TOKEN" }
+token = { env = "GH_TOKEN", default = "" }
 
 [tool.semantic_release.changelog.default_templates]
 changelog_file = "CHANGELOG.md"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk configuration-only change; it mainly affects the Python release pipeline by adjusting how the GitHub token is read and adding an empty `CHANGELOG.md` target file.
> 
> **Overview**
> Fixes Python semantic-release configuration by making the GitHub token env var (`GH_TOKEN`) optional via a default empty string, avoiding failures when the variable is unset.
> 
> Adds an initial `packages/python/CHANGELOG.md` file and points semantic-release changelog output at it.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8ae323b835755e9c795055cfe3f031ec8ee3d3f4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->