### PR TITLE
Fix memory leak: clean up spanToRoot entry for hidden chains in endSpan

### DIFF
--- a/packages/ts/langgraph/src/callback-handler.ts
+++ b/packages/ts/langgraph/src/callback-handler.ts
@@ -509,6 +509,7 @@ export class TCCCallbackHandler
     if (inv.skippedRuns.has(runId)) {
       inv.skippedRuns.delete(runId);
       inv.spans.delete(runId);
+      this.spanToRoot.delete(runId);
       return;
     }
 


### PR DESCRIPTION
When a chain tagged 'langsmith:hidden' starts, its runId is added to spanToRoot but never to inv.spans. When endSpan handles the skipped run, it removes from skippedRuns and inv.spans but not spanToRoot. During flushInvocation, cleanup only iterates inv.spans.keys(), so the hidden chain's spanToRoot entry persists indefinitely.

Add this.spanToRoot.delete(runId) in the skipped-run branch of endSpan so the entry is cleaned up when the hidden chain ends.

## 🎯 Changes

What changes are made in this PR? Is it a feature or a bug fix?

## ✅ Checklist

- [ ] I have followed the steps listed in the Contributing guide.
- [ ] If necessary, I have added documentation related to the changes made.
- [ ] If applicable, I have added or updated the tests related to the changes made.

## 🔒 Related Issues

Closes #

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small cleanup change in `endSpan` that only affects internal bookkeeping for skipped/hidden runs and should not alter emitted trace payloads.
> 
> **Overview**
> Fixes a memory leak in `TCCCallbackHandler` by deleting the `spanToRoot` mapping when `endSpan` finishes a skipped (e.g., `langsmith:hidden`) run, ensuring hidden runs don’t leave behind root-span references that never get cleaned up.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a0dcd7aba157f5019125c8518ce5c2ee5713d248. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->