### PR TITLE
fix: remove right-side overflow on mobile for popover widget

### DIFF
--- a/packages/ts/widget/src/components/data-block.tsx
+++ b/packages/ts/widget/src/components/data-block.tsx
@@ -83,7 +83,7 @@ function DataBlock({
         <Copyable content={content}>
           <div
             className={cn(
-              "group bg-white rounded p-3 border border-gray-300 relative font-mono text-xs",
+              "group bg-white rounded p-3 border border-gray-300 relative font-mono text-xs overflow-x-auto",
               className
             )}
           >

--- a/packages/ts/widget/src/components/popover/popover.tsx
+++ b/packages/ts/widget/src/components/popover/popover.tsx
@@ -1,5 +1,5 @@
 import { cn } from "@/utils/cn";
-import { getPositionFromWidget } from "@/utils/corners";
+import { getPositionFromWidget, SAFE_AREA_MARGIN } from "@/utils/corners";
 import {
   useCallback,
   useEffect,
@@ -19,6 +19,15 @@ import RunViewer from "./run-viewer/run-viewer";
 import { ResizableHandles } from "./ResizableHandle";
 import { X } from "lucide-preact";
 import { captureAnonymousEvent } from "@/internal/events";
+
+const clampToViewport = (width: number, height: number) => {
+  const maxWidth = window.innerWidth - SAFE_AREA_MARGIN * 2;
+  const maxHeight = window.innerHeight - SAFE_AREA_MARGIN * 2;
+  return {
+    width: Math.min(width, Math.max(300, maxWidth)),
+    height: Math.min(height, Math.max(200, maxHeight)),
+  };
+};
 
 type Tab = "Agent runs" | "Tool calls" | "Failures";
 
@@ -88,15 +97,12 @@ function Popover() {
     if (!popover) return;
 
     if (selectedTraceIdSignal.value) {
-      popoverDimensionSignal.value = {
-        width: window.innerWidth * 0.6,
-        height: window.innerHeight * 0.7,
-      };
+      popoverDimensionSignal.value = clampToViewport(
+        window.innerWidth * 0.6,
+        window.innerHeight * 0.7
+      );
     } else {
-      popoverDimensionSignal.value = {
-        width: 630,
-        height: 400,
-      };
+      popoverDimensionSignal.value = clampToViewport(630, 400);
     }
 
     const { x, y } = getPositionFromWidget({
@@ -113,26 +119,25 @@ function Popover() {
     if (!popover) return;
 
     if (!selectedTraceIdSignal.value) {
+      const clamped = clampToViewport(630, 400);
       const { x, y } = getPositionFromWidget({
-        targetWidth: 630,
-        targetHeight: 400,
+        targetWidth: clamped.width,
+        targetHeight: clamped.height,
       });
 
-      popoverDimensionSignal.value = {
-        width: 630,
-        height: 400,
-      };
+      popoverDimensionSignal.value = clamped;
       popover.style.transform = `translate3d(${x}px, ${y}px, 0)`;
       return;
     }
 
-    // check if any part of the element will be outside of the window
     const { x: popoverX, y: popoverY } = popover.getBoundingClientRect();
     const windowWidth = window.innerWidth;
     const windowHeight = window.innerHeight;
 
-    const newWidth = window.innerWidth * 0.6;
-    const newHeight = window.innerHeight * 0.7;
+    const { width: newWidth, height: newHeight } = clampToViewport(
+      window.innerWidth * 0.6,
+      window.innerHeight * 0.7
+    );
 
     const isOutsideWindowX = newWidth + popoverX > windowWidth || popoverX < 0;
     const isOutsideWindowY =
@@ -189,6 +194,7 @@ function Popover() {
         left: 0,
         width: `${popoverDimensionSignal.value.width}px`,
         height: `${popoverDimensionSignal.value.height}px`,
+        maxWidth: `calc(100vw - ${SAFE_AREA_MARGIN * 2}px)`,
       }}
     >
       {selectedTraceIdSignal.value ? (

--- a/packages/ts/widget/src/styles.css
+++ b/packages/ts/widget/src/styles.css
@@ -814,6 +814,9 @@
   .overflow-hidden {
     overflow: hidden;
   }
+  .overflow-x-auto {
+    overflow-x: auto;
+  }
   .overflow-x-hidden {
     overflow-x: hidden;
   }

--- a/packages/ts/widget/src/utils/corners.ts
+++ b/packages/ts/widget/src/utils/corners.ts
@@ -102,6 +102,9 @@ export const getPositionFromWidget = ({
       break;
   }
 
+  x = Math.max(SAFE_AREA_MARGIN, Math.min(x, window.innerWidth - targetWidth - SAFE_AREA_MARGIN));
+  y = Math.max(SAFE_AREA_MARGIN, Math.min(y, window.innerHeight - targetHeight - SAFE_AREA_MARGIN));
+
   return { x, y };
 };
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 🎯 Changes

Fixes right-side horizontal overflow on mobile devices caused by the popover widget exceeding the viewport width.

**Root cause:** The popover used a hardcoded 630px width, which is wider than most mobile viewports (320–428px). Additionally, the positioning logic could place the popover off-screen.

**Changes:**

- **`popover.tsx`** — Added a `clampToViewport` helper that caps popover width/height to `window.innerWidth - 32px` (using the existing 16px safe area margin on each side). Applied to both collapsed (630×400) and expanded (60%×70%) dimension calculations. Also added a `max-width: calc(100vw - 32px)` CSS safeguard on the popover container.

- **`corners.ts`** — Clamped the `x`/`y` output of `getPositionFromWidget` to keep the popover within viewport bounds, preventing it from being positioned off the right or bottom edge.

- **`data-block.tsx`** — Added `overflow-x-auto` on the content container to prevent long content (JSON, Markdown, code) from overflowing the popover horizontally.

## ✅ Checklist

- [x] I have followed the steps listed in the Contributing guide.
- [ ] If necessary, I have added documentation related to the changes made.
- [ ] If applicable, I have added or updated the tests related to the changes made.

## 🔒 Related Issues

Closes #
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-be44cc7e-2ab6-40f9-bb4e-a474532c16b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-be44cc7e-2ab6-40f9-bb4e-a474532c16b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

