### PR TITLE
feat(openclaw): expose runId, metadata, and sessionId to users

### DIFF
--- a/.changeset/openclaw-per-run-ids-and-callbacks.md
+++ b/.changeset/openclaw-per-run-ids-and-callbacks.md
@@ -19,4 +19,4 @@ The plugin now sends `tcc.runId`, `tcc.sessionId`, and `tcc.conversational` insi
 **Fixes**
 
 - `run_id` is now unique per agent turn. Previously the converter fell back to OpenClaw's internal stable run identifier, which caused multiple turns in the same session to share a run ID.
-- `session_id` can now be bound to a channel thread (e.g. `slack:<channel>:<thread_ts>`) via a custom extension, grouping all runs in a thread under one TCC session. Previously `session_id` was a random UUID regenerated per turn.
+- `session_id` is now thread-scoped for channel-based setups out of the box. The plugin listens on `before_dispatch` and auto-derives `sessionId` as `<accountId>:<channelId>:<conversationId>` whenever both are available (Slack threads, Discord threads, Telegram chats, iMessage conversations, etc.). Falls back to `ctx.sessionKey` for non-channel flows (CLI, cron, subagents). User overrides via config `sessionId` or `onRunStart`'s `setSessionId` always win.

--- a/.changeset/openclaw-per-run-ids-and-callbacks.md
+++ b/.changeset/openclaw-per-run-ids-and-callbacks.md
@@ -1,0 +1,22 @@
+---
+"@contextcompany/openclaw": minor
+---
+
+Per-turn run IDs, per-thread sessions, and callback-based instrumentation.
+
+**What changed**
+
+- Plugin now hooks `before_agent_start` and mints a fresh UUID run ID for every agent turn. Per-session state is keyed by `sessionKey`, so concurrent sessions (e.g. multiple Slack threads) no longer clobber each other.
+- New `onRunStart` and `onRunEnd` callbacks give you per-run access to the run ID, Slack/Discord/etc. thread context, and mutators: `setRunId`, `setSessionId`, `setMetadata`.
+- `sessionId` and `metadata` config fields now accept either a static value or a function `(ctx) => value` so they can be derived from the agent context.
+- New handle methods: `getRunIdForSession(sessionKey)` for concurrency-safe lookup, `setRunContext(sessionKey, { runId, sessionId, metadata })` for imperative overrides.
+- Re-exports `submitFeedback` from `@contextcompany/api` so you can close the loop: capture the run ID in `onRunEnd`, submit feedback later.
+
+**Payload shape change**
+
+The plugin now sends `tcc.runId`, `tcc.sessionId`, and `tcc.conversational` inside `metadata`, matching the convention used by the Vercel AI SDK, LangChain, Agno, Mastra, and Claude Agent SDK integrations. The ingest converter accepts both the new and legacy shapes, so you can upgrade the package without coordinating with the server.
+
+**Fixes**
+
+- `run_id` is now unique per agent turn. Previously the converter fell back to OpenClaw's internal stable run identifier, which caused multiple turns in the same session to share a run ID.
+- `session_id` can now be bound to a channel thread (e.g. `slack:<channel>:<thread_ts>`) via a custom extension, grouping all runs in a thread under one TCC session. Previously `session_id` was a random UUID regenerated per turn.

--- a/examples/openclaw/README.md
+++ b/examples/openclaw/README.md
@@ -1,8 +1,8 @@
 # OpenClaw + TCC Observability
 
-Example showing how to add TCC instrumentation to an [OpenClaw](https://openclaw.ai) agent with run ID and metadata support.
+Example showing how to add TCC instrumentation to an [OpenClaw](https://openclaw.ai) agent with per-run IDs, session grouping, and custom metadata.
 
-## Option 1: Plugin Install (recommended)
+## Option 1: Plugin Install (quickest)
 
 ```bash
 openclaw plugins install @contextcompany/openclaw
@@ -37,23 +37,69 @@ Restart the gateway:
 openclaw gateway restart
 ```
 
-## Option 2: Custom Extension (with run ID access)
+Every agent turn will auto-mint a fresh UUID as its runId, tagged with the config's `sessionId` and `metadata`.
 
-Use this approach when you need programmatic access to run IDs — e.g. to submit feedback after a run completes.
+## Option 2: Custom Extension (recommended for real apps)
 
-1. Copy `extensions/tcc-observability/` into your OpenClaw extensions directory.
+Use this when you need per-run control — e.g. a Slack bot where each thread is a session, each prompt needs its own UUID, and you want to capture the runId for feedback.
 
-2. Add `TCC_API_KEY` to your environment.
+1. Copy [`extensions/tcc-observability/`](./extensions/tcc-observability/) into your OpenClaw extensions directory.
 
-3. The extension registers the plugin and exposes the handle, which you can use to retrieve run IDs.
+2. Set `TCC_API_KEY` in your environment.
 
-See [`extensions/tcc-observability/index.ts`](./extensions/tcc-observability/index.ts) for the full example.
+3. Edit `extensions/tcc-observability/index.ts` — the `onRunStart` / `onRunEnd` callbacks run once per turn.
 
-## Run ID Flow
+## Per-run API
 
+```ts
+import { register } from "@contextcompany/openclaw";
+
+const handle = register(api, {
+  // Layer 1 — static defaults (applied to every run as fallbacks)
+  sessionId: (ctx) => ctx.sessionKey ?? "default",
+  metadata:  (ctx) => ({ channel: ctx.channelId ?? "unknown" }),
+
+  // Layer 2 — per-run overrides via callbacks (the main knob)
+  onRunStart: ({ runId, ctx, prompt, setRunId, setSessionId, setMetadata }) => {
+    // `runId` is an auto-minted UUID — keep it, or override:
+    // setRunId(myUuid);
+
+    setSessionId(`slack-${ctx.channelId}-${threadTs}`);
+    setMetadata({
+      slackUserId: extractUser(prompt),
+      promptPreview: prompt.slice(0, 120),
+    });
+  },
+
+  onRunEnd: ({ runId, ctx, success }) => {
+    // Stash runId for feedback button
+    lastRunByThread.set(ctx.sessionKey, runId);
+    // Or submit feedback directly:
+    //   import { submitFeedback } from "@contextcompany/otel";
+    //   await submitFeedback({ runId, score: "thumbs_up" });
+  },
+});
 ```
-register(api, config)  →  handle
-                              ├── handle.setRunId("custom-id")   // before a run
-                              ├── handle.getRunId()              // after a run → use for feedback
-                              └── handle.setMetadata({ ... })    // anytime
+
+### Layer 3 — imperative, outside callbacks
+
+```ts
+handle.setRunContext(sessionKey, {
+  runId: crypto.randomUUID(),
+  metadata: { foo: "bar" },
+});
 ```
+
+Precedence per run: **Layer 3 > Layer 2 > Layer 1 > auto-mint**. Metadata is shallow-merged; runId / sessionId are replaced.
+
+### Concurrency-safe lookup
+
+`handle.getRunId()` returns the last run globally — under concurrency, prefer:
+
+```ts
+handle.getRunIdForSession(sessionKey); // per-session, safe
+```
+
+## Important: UUID format for feedback
+
+The TCC feedback and metadata HTTP endpoints validate `runId` against strict UUID v4 format. Auto-minted runIds are always valid. If you override via `setRunId`, use `crypto.randomUUID()` (or another UUID source) — non-UUID strings will be rejected by the feedback endpoint with 400.

--- a/examples/openclaw/README.md
+++ b/examples/openclaw/README.md
@@ -1,0 +1,59 @@
+# OpenClaw + TCC Observability
+
+Example showing how to add TCC instrumentation to an [OpenClaw](https://openclaw.ai) agent with run ID and metadata support.
+
+## Option 1: Plugin Install (recommended)
+
+```bash
+openclaw plugins install @contextcompany/openclaw
+```
+
+Then add to your `~/.openclaw/openclaw.json`:
+
+```json5
+{
+  "plugins": {
+    "allow": ["@contextcompany/openclaw"],
+    "entries": {
+      "@contextcompany/openclaw": {
+        "enabled": true,
+        "config": {
+          "apiKey": "${TCC_API_KEY}",
+          "sessionId": "my-session-123",
+          "metadata": {
+            "environment": "development",
+            "userId": "user_abc"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+Restart the gateway:
+
+```bash
+openclaw gateway restart
+```
+
+## Option 2: Custom Extension (with run ID access)
+
+Use this approach when you need programmatic access to run IDs — e.g. to submit feedback after a run completes.
+
+1. Copy `extensions/tcc-observability/` into your OpenClaw extensions directory.
+
+2. Add `TCC_API_KEY` to your environment.
+
+3. The extension registers the plugin and exposes the handle, which you can use to retrieve run IDs.
+
+See [`extensions/tcc-observability/index.ts`](./extensions/tcc-observability/index.ts) for the full example.
+
+## Run ID Flow
+
+```
+register(api, config)  →  handle
+                              ├── handle.setRunId("custom-id")   // before a run
+                              ├── handle.getRunId()              // after a run → use for feedback
+                              └── handle.setMetadata({ ... })    // anytime
+```

--- a/examples/openclaw/extensions/tcc-observability/index.ts
+++ b/examples/openclaw/extensions/tcc-observability/index.ts
@@ -1,13 +1,14 @@
 /**
- * OpenClaw extension: TCC observability with run ID + metadata support.
+ * OpenClaw extension: TCC observability with per-run IDs and metadata.
  *
- * Place this in your OpenClaw extensions directory and the gateway
+ * Drop this file into your OpenClaw extensions directory — the gateway
  * will load it automatically on startup.
  *
- * The handle returned by register() lets you:
- *   - Get the run ID after a run completes (for feedback submission)
- *   - Set a custom run ID before the next run starts
- *   - Attach metadata to all subsequent runs
+ * What it demonstrates:
+ *   - Auto-minted UUID per agent turn (safe for concurrent Slack threads).
+ *   - Per-run metadata via `onRunStart` (e.g. user id, channel, prompt preview).
+ *   - Feedback hookup via `onRunEnd` (log or stash the runId for a 👍/👎 button).
+ *   - Custom runId override when the caller wants deterministic IDs.
  */
 
 import { register, type OpenClawHandle } from "@contextcompany/openclaw";
@@ -16,41 +17,58 @@ let handle: OpenClawHandle;
 
 export default async function (api: any) {
   handle = register(api, {
-    // API key — falls back to TCC_API_KEY env var if not set here
+    // API key — falls back to TCC_API_KEY env var if not set here.
     // apiKey: "tcc_...",
 
-    // Group runs in the same conversation
-    sessionId: "my-session-id",
+    // Default session id applied to every run. `ctx.sessionKey` is stable
+    // per OpenClaw session — in Slack with thread-bound sessions, this
+    // maps 1:1 to a thread.
+    sessionId: (ctx) => ctx.sessionKey ?? "default",
 
-    // Attach metadata to every run
-    metadata: {
-      environment: "production",
-      userId: "user_abc",
+    // Default metadata merged into every run. Per-run overrides win.
+    metadata: (ctx) => ({
+      channel: ctx.channelId ?? "unknown",
+      agent: ctx.agentId ?? "unknown",
+    }),
+
+    // Called at before_agent_start for every new turn. `runId` is the
+    // auto-minted UUID for this run; override or enrich it here.
+    onRunStart: ({ runId, ctx, prompt, setRunId, setMetadata }) => {
+      // Example: override with a caller-supplied UUID if available.
+      // setRunId(myUuid);
+
+      // Example: attach per-run metadata.
+      setMetadata({
+        promptPreview: prompt.slice(0, 120),
+        trigger: ctx.trigger ?? "user",
+      });
+
+      console.log(`[tcc] run start — runId: ${runId} session: ${ctx.sessionKey}`);
+    },
+
+    // Called at agent_end after the payload is flushed. Use this to wire
+    // up feedback — stash the runId somewhere the user's 👍/👎 button
+    // can read, or post an ephemeral message to the thread.
+    onRunEnd: ({ runId, ctx, success }) => {
+      console.log(
+        `[tcc] run end — runId: ${runId} success: ${success} session: ${ctx.sessionKey}`,
+      );
+      // Example:
+      //   import { submitFeedback } from "@contextcompany/otel";
+      //   lastRunIdByThread.set(ctx.sessionKey, runId);
+      //   // later, when user clicks 👍:
+      //   await submitFeedback({ runId, score: "thumbs_up" });
     },
 
     debug: true,
   });
-
-  // --- Example: hook into agent_end to log the run ID ---
-
-  api.on("agent_end", () => {
-    // getRunId() returns the ID of the run that just finished
-    const runId = handle.getRunId();
-    console.log(`[tcc] run finished — runId: ${runId}`);
-
-    // You can now use this runId to submit feedback:
-    //
-    //   import { submitFeedback } from "@contextcompany/otel";
-    //   await submitFeedback({ runId, score: "thumbs_up" });
-  });
 }
 
 /**
- * Export the handle so other extensions can access it if needed.
+ * Expose the handle for other extensions.
  *
- * Example from another extension:
  *   import { getHandle } from "../tcc-observability/index.ts";
- *   const runId = getHandle().getRunId();
+ *   const runId = getHandle().getRunIdForSession(sessionKey);
  */
 export function getHandle(): OpenClawHandle {
   return handle;

--- a/examples/openclaw/extensions/tcc-observability/index.ts
+++ b/examples/openclaw/extensions/tcc-observability/index.ts
@@ -1,0 +1,57 @@
+/**
+ * OpenClaw extension: TCC observability with run ID + metadata support.
+ *
+ * Place this in your OpenClaw extensions directory and the gateway
+ * will load it automatically on startup.
+ *
+ * The handle returned by register() lets you:
+ *   - Get the run ID after a run completes (for feedback submission)
+ *   - Set a custom run ID before the next run starts
+ *   - Attach metadata to all subsequent runs
+ */
+
+import { register, type OpenClawHandle } from "@contextcompany/openclaw";
+
+let handle: OpenClawHandle;
+
+export default async function (api: any) {
+  handle = register(api, {
+    // API key — falls back to TCC_API_KEY env var if not set here
+    // apiKey: "tcc_...",
+
+    // Group runs in the same conversation
+    sessionId: "my-session-id",
+
+    // Attach metadata to every run
+    metadata: {
+      environment: "production",
+      userId: "user_abc",
+    },
+
+    debug: true,
+  });
+
+  // --- Example: hook into agent_end to log the run ID ---
+
+  api.on("agent_end", () => {
+    // getRunId() returns the ID of the run that just finished
+    const runId = handle.getRunId();
+    console.log(`[tcc] run finished — runId: ${runId}`);
+
+    // You can now use this runId to submit feedback:
+    //
+    //   import { submitFeedback } from "@contextcompany/otel";
+    //   await submitFeedback({ runId, score: "thumbs_up" });
+  });
+}
+
+/**
+ * Export the handle so other extensions can access it if needed.
+ *
+ * Example from another extension:
+ *   import { getHandle } from "../tcc-observability/index.ts";
+ *   const runId = getHandle().getRunId();
+ */
+export function getHandle(): OpenClawHandle {
+  return handle;
+}

--- a/examples/openclaw/extensions/tcc-observability/index.ts
+++ b/examples/openclaw/extensions/tcc-observability/index.ts
@@ -1,63 +1,48 @@
 /**
- * OpenClaw extension: TCC observability with per-run IDs and metadata.
+ * OpenClaw extension: TCC observability with per-run metadata + feedback wiring.
  *
- * Drop this file into your OpenClaw extensions directory — the gateway
- * will load it automatically on startup.
+ * You do NOT need this extension for the common case — just install the
+ * plugin (`openclaw plugins install @contextcompany/openclaw`). The plugin
+ * already auto-generates a unique runId per turn and auto-scopes sessionId
+ * to the conversation thread for channel-based setups.
  *
- * What it demonstrates:
- *   - Auto-minted UUID per agent turn (safe for concurrent Slack threads).
- *   - Per-run metadata via `onRunStart` (e.g. user id, channel, prompt preview).
- *   - Feedback hookup via `onRunEnd` (log or stash the runId for a 👍/👎 button).
- *   - Custom runId override when the caller wants deterministic IDs.
+ * Use this extension only when you need:
+ *   - Per-run metadata (e.g. the Slack user who sent the message).
+ *   - A deterministic runId supplied by your caller.
+ *   - Feedback wiring: capture runId per thread so a 👍/👎 reaction or
+ *     slash command can later call submitFeedback({ runId }).
  */
 
-import { register, type OpenClawHandle } from "@contextcompany/openclaw";
+import { register, submitFeedback, type OpenClawHandle } from "@contextcompany/openclaw";
 
 let handle: OpenClawHandle;
+
+// Stashed by onRunEnd. Lets a reaction or slash-command handler look up
+// the most recent runId for a given conversation.
+const runIdByConversation = new Map<string, string>();
 
 export default async function (api: any) {
   handle = register(api, {
     // API key — falls back to TCC_API_KEY env var if not set here.
     // apiKey: "tcc_...",
 
-    // Default session id applied to every run. `ctx.sessionKey` is stable
-    // per OpenClaw session — in Slack with thread-bound sessions, this
-    // maps 1:1 to a thread.
-    sessionId: (ctx) => ctx.sessionKey ?? "default",
-
-    // Default metadata merged into every run. Per-run overrides win.
-    metadata: (ctx) => ({
-      channel: ctx.channelId ?? "unknown",
-      agent: ctx.agentId ?? "unknown",
-    }),
-
-    // Called at before_agent_start for every new turn. `runId` is the
-    // auto-minted UUID for this run; override or enrich it here.
     onRunStart: ({ runId, ctx, prompt, setRunId, setMetadata }) => {
-      // Example: override with a caller-supplied UUID if available.
-      // setRunId(myUuid);
+      // runId is the auto-minted UUID. Override with your own if needed:
+      // setRunId(myCallerUuid);
 
-      // Example: attach per-run metadata.
+      // Attach per-run metadata. Anything you put here is filterable in
+      // the TCC dashboard.
       setMetadata({
-        promptPreview: prompt.slice(0, 120),
+        agent: ctx.agentId ?? "unknown",
         trigger: ctx.trigger ?? "user",
+        promptPreview: prompt.slice(0, 120),
       });
-
-      console.log(`[tcc] run start — runId: ${runId} session: ${ctx.sessionKey}`);
     },
 
-    // Called at agent_end after the payload is flushed. Use this to wire
-    // up feedback — stash the runId somewhere the user's 👍/👎 button
-    // can read, or post an ephemeral message to the thread.
-    onRunEnd: ({ runId, ctx, success }) => {
-      console.log(
-        `[tcc] run end — runId: ${runId} success: ${success} session: ${ctx.sessionKey}`,
-      );
-      // Example:
-      //   import { submitFeedback } from "@contextcompany/otel";
-      //   lastRunIdByThread.set(ctx.sessionKey, runId);
-      //   // later, when user clicks 👍:
-      //   await submitFeedback({ runId, score: "thumbs_up" });
+    onRunEnd: ({ runId, ctx }) => {
+      // Stash the runId by conversation so a reaction handler can retrieve
+      // it. sessionKey is a stable per-conversation key in OpenClaw.
+      if (ctx.sessionKey) runIdByConversation.set(ctx.sessionKey, runId);
     },
 
     debug: true,
@@ -65,11 +50,20 @@ export default async function (api: any) {
 }
 
 /**
- * Expose the handle for other extensions.
+ * Look up the runId for the most recent run in a conversation. Use from
+ * your own reaction/slash-command handler when a user gives feedback:
  *
- *   import { getHandle } from "../tcc-observability/index.ts";
- *   const runId = getHandle().getRunIdForSession(sessionKey);
+ *   const runId = getRunIdForConversation(sessionKey);
+ *   if (runId) await submitFeedback({ runId, score: "thumbs_up" });
  */
+export function getRunIdForConversation(sessionKey: string): string | undefined {
+  return runIdByConversation.get(sessionKey);
+}
+
+/** Expose the handle so other extensions can reach it. */
 export function getHandle(): OpenClawHandle {
   return handle;
 }
+
+// Re-export for convenience.
+export { submitFeedback };

--- a/examples/openclaw/openclaw.json
+++ b/examples/openclaw/openclaw.json
@@ -1,0 +1,18 @@
+{
+  "plugins": {
+    "allow": ["@contextcompany/openclaw"],
+    "entries": {
+      "@contextcompany/openclaw": {
+        "enabled": true,
+        "config": {
+          "apiKey": "${TCC_API_KEY}",
+          "sessionId": "my-session-123",
+          "metadata": {
+            "environment": "development",
+            "userId": "user_abc"
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/ts/openclaw/README.md
+++ b/packages/ts/openclaw/README.md
@@ -49,18 +49,41 @@ If you prefer to register from a custom extension:
 import { register } from "@contextcompany/openclaw";
 
 export default async function (api) {
-  register(api);
+  const handle = register(api);
+
+  // After a run completes, get the run ID (e.g. for feedback)
+  const runId = handle.getRunId();
 }
 ```
 
 With explicit config:
 
 ```ts
-register(api, {
+const handle = register(api, {
   apiKey: "tcc_...",
   endpoint: "https://api.thecontext.company/v1/openclaw",
   debug: true,
+  runId: "my-custom-run-id",       // optional: set a specific run ID
+  sessionId: "conversation-123",   // optional: group runs in a session
+  metadata: { userId: "u_abc" },   // optional: attach metadata to runs
 });
+```
+
+### Run ID & Metadata Access
+
+`register()` returns a handle you can use to control run IDs and metadata:
+
+```ts
+const handle = register(api, { apiKey: "tcc_..." });
+
+// Set the run ID for the *next* run (before it starts)
+handle.setRunId("my-custom-run-id");
+
+// Get the run ID of the last (or current) run (e.g. to submit feedback)
+const runId = handle.getRunId();
+
+// Add metadata for subsequent runs
+handle.setMetadata({ userId: "u_abc", environment: "staging" });
 ```
 
 ## Configuration
@@ -70,6 +93,9 @@ register(api, {
 | `apiKey` | `TCC_API_KEY` | — | Your Context Company API key |
 | `endpoint` | `TCC_URL` | Auto-detected from key | Ingestion endpoint URL |
 | `debug` | `TCC_DEBUG` | `false` | Enable debug logging |
+| `runId` | — | Random UUID | Explicit run ID for the first run |
+| `sessionId` | — | — | Session ID to group related runs |
+| `metadata` | — | — | Key-value metadata attached to runs |
 
 ## How It Works
 

--- a/packages/ts/openclaw/openclaw.plugin.json
+++ b/packages/ts/openclaw/openclaw.plugin.json
@@ -9,7 +9,10 @@
       "enabled": { "type": "boolean" },
       "apiKey": { "type": "string" },
       "endpoint": { "type": "string" },
-      "debug": { "type": "boolean" }
+      "debug": { "type": "boolean" },
+      "runId": { "type": "string" },
+      "sessionId": { "type": "string" },
+      "metadata": { "type": "object", "additionalProperties": { "type": "string" } }
     }
   },
   "uiHints": {
@@ -31,6 +34,20 @@
     "debug": {
       "label": "Debug Logging",
       "help": "Log hook events and transport details to console."
+    },
+    "runId": {
+      "label": "Run ID",
+      "placeholder": "my-custom-run-id",
+      "help": "Explicit run ID for the first run. If not set, a random UUID is generated."
+    },
+    "sessionId": {
+      "label": "Session ID",
+      "placeholder": "conversation-123",
+      "help": "Group multiple runs in the same conversation or session."
+    },
+    "metadata": {
+      "label": "Metadata",
+      "help": "Arbitrary key-value metadata attached to every run."
     }
   }
 }

--- a/packages/ts/openclaw/openclaw.plugin.json
+++ b/packages/ts/openclaw/openclaw.plugin.json
@@ -1,5 +1,5 @@
 {
-  "id": "@contextcompany/openclaw",
+  "id": "openclaw",
   "name": "The Context Company",
   "description": "Agent observability — captures LLM calls, tool executions, and agent lifecycle events",
   "configSchema": {

--- a/packages/ts/openclaw/src/index.ts
+++ b/packages/ts/openclaw/src/index.ts
@@ -1,1 +1,6 @@
-export { default, register, type OpenClawPluginConfig } from "./plugin.js";
+export {
+  default,
+  register,
+  type OpenClawPluginConfig,
+  type OpenClawHandle,
+} from "./plugin.js";

--- a/packages/ts/openclaw/src/index.ts
+++ b/packages/ts/openclaw/src/index.ts
@@ -4,3 +4,5 @@ export {
   type OpenClawPluginConfig,
   type OpenClawHandle,
 } from "./plugin.js";
+
+export { submitFeedback } from "@contextcompany/api";

--- a/packages/ts/openclaw/src/plugin.ts
+++ b/packages/ts/openclaw/src/plugin.ts
@@ -80,6 +80,13 @@ function registerHooks(
     string,
     { runId?: string; sessionId?: string; metadata?: Record<string, string> }
   >();
+  // Populated by before_dispatch for channel-based setups (Slack, Discord,
+  // Telegram, iMessage, etc). Lets us auto-scope sessionId to a conversation
+  // (e.g. a Slack thread) without the user writing an extension.
+  const threadBySessionKey = new Map<
+    string,
+    { accountId?: string; channelId: string; conversationId?: string }
+  >();
 
   const merged: Record<string, unknown> = {
     ...(api.pluginConfig ?? {}),
@@ -201,14 +208,25 @@ function registerHooks(
       runId = crypto.randomUUID();
     }
 
+    // sessionId resolution order:
+    //   1. user config `sessionId` (static or function)
+    //   2. auto-derived from before_dispatch (channel + conversation, e.g.
+    //      Slack thread) so a thread maps to a stable TCC session
+    //   3. ctx.sessionKey as the last-ditch fallback
     const defaultSessionId = resolveDefaultSessionId(pluginConfig.sessionId, ctx);
+    const thread = threadBySessionKey.get(sessionKey);
+    const dispatchSessionId = thread
+      ? [thread.accountId, thread.channelId, thread.conversationId]
+          .filter((v): v is string => typeof v === "string" && v.length > 0)
+          .join(":")
+      : undefined;
     const defaultMetadata = resolveDefaultMetadata(pluginConfig.metadata, ctx);
 
     session = {
       events: [],
       startedAt: Date.now(),
       runId,
-      sessionId: defaultSessionId ?? ctx.sessionKey,
+      sessionId: defaultSessionId ?? dispatchSessionId ?? ctx.sessionKey,
       metadata: defaultMetadata,
     };
     activeSessions.set(sessionKey, session);
@@ -245,6 +263,29 @@ function registerHooks(
   // -------------------------------------------------------------------
   // Hooks
   // -------------------------------------------------------------------
+
+  // Channel-based setups (Slack, Discord, Telegram, iMessage, …) fire
+  // before_dispatch with both sessionKey AND conversationId in context.
+  // Stash so we can map thread → sessionId when the agent turn starts.
+  //
+  // Non-channel setups (agent CLI, cron, subagents) never fire this, so
+  // the default falls back to ctx.sessionKey unchanged.
+  api.on("before_dispatch", (_event: any, ctx: any) => {
+    const sessionKey: string | undefined = ctx?.sessionKey;
+    const channelId: string | undefined = ctx?.channelId;
+    if (!sessionKey || !channelId) return;
+    threadBySessionKey.set(sessionKey, {
+      accountId: typeof ctx?.accountId === "string" ? ctx.accountId : undefined,
+      channelId,
+      conversationId:
+        typeof ctx?.conversationId === "string" ? ctx.conversationId : undefined,
+    });
+  });
+
+  api.on("session_end", (_event: any, ctx: any) => {
+    const sessionKey: string | undefined = ctx?.sessionKey;
+    if (sessionKey) threadBySessionKey.delete(sessionKey);
+  });
 
   api.on("before_agent_start", async (event: any, ctx: any) => {
     const runCtx = toRunContext(ctx);

--- a/packages/ts/openclaw/src/plugin.ts
+++ b/packages/ts/openclaw/src/plugin.ts
@@ -364,6 +364,12 @@ function registerHooks(
       const session = activeSessions.get(sessionKey);
       if (!session) return;
 
+      // Detach the session from the map BEFORE any await. If a rapid
+      // follow-up turn arrives for the same sessionKey while we're
+      // awaiting onRunEnd, ensureSession must create a fresh session
+      // rather than appending to this already-flushed one.
+      activeSessions.delete(sessionKey);
+
       if (debug)
         log.info(
           `agent_end — sending ${session.events.length} events (runId: ${session.runId})`,
@@ -388,8 +394,6 @@ function registerHooks(
           log.warn(`onRunEnd threw: ${err}`);
         }
       }
-
-      activeSessions.delete(sessionKey);
     });
   });
 

--- a/packages/ts/openclaw/src/plugin.ts
+++ b/packages/ts/openclaw/src/plugin.ts
@@ -4,24 +4,89 @@
  * Thin forwarder: collects raw hook events during an agent run,
  * then sends them all as one batch on agent_end.
  *
+ * Per-session state is keyed by ctx.sessionKey — safe under concurrent
+ * runs (e.g. multiple Slack threads served by the same gateway).
+ *
  * All parsing/transformation happens server-side.
  */
 
 import { getTCCApiKey, getTCCUrl } from "@contextcompany/api";
-import type { ActiveSession, OpenClawHandle, OpenClawPluginConfig } from "./types.js";
-export type { OpenClawPluginConfig, OpenClawHandle } from "./types.js";
+import type {
+  ActiveSession,
+  OpenClawHandle,
+  OpenClawPluginConfig,
+  OpenClawRunContext,
+  OpenClawRunStartHandler,
+  OpenClawRunEndHandler,
+  OpenClawDefaultSessionId,
+  OpenClawDefaultMetadata,
+} from "./types.js";
+export type {
+  OpenClawPluginConfig,
+  OpenClawHandle,
+  OpenClawRunContext,
+  OpenClawRunStartHandler,
+  OpenClawRunEndHandler,
+} from "./types.js";
 import { safeClone, sendToTcc } from "./transport.js";
+
+function resolveDefaultSessionId(
+  def: OpenClawDefaultSessionId | undefined,
+  ctx: OpenClawRunContext,
+): string | undefined {
+  if (typeof def === "function") {
+    try {
+      return def(ctx);
+    } catch {
+      return undefined;
+    }
+  }
+  return def;
+}
+
+function resolveDefaultMetadata(
+  def: OpenClawDefaultMetadata | undefined,
+  ctx: OpenClawRunContext,
+): Record<string, string> {
+  if (typeof def === "function") {
+    try {
+      return { ...(def(ctx) ?? {}) };
+    } catch {
+      return {};
+    }
+  }
+  return { ...(def ?? {}) };
+}
+
+function toRunContext(ctx: unknown): OpenClawRunContext {
+  const c = (ctx ?? {}) as Record<string, unknown>;
+  return {
+    agentId: typeof c.agentId === "string" ? c.agentId : undefined,
+    sessionKey: typeof c.sessionKey === "string" ? c.sessionKey : undefined,
+    sessionId: typeof c.sessionId === "string" ? c.sessionId : undefined,
+    channelId: typeof c.channelId === "string" ? c.channelId : undefined,
+    workspaceDir: typeof c.workspaceDir === "string" ? c.workspaceDir : undefined,
+    trigger: typeof c.trigger === "string" ? c.trigger : undefined,
+  };
+}
 
 function registerHooks(
   api: any,
   configOverrides?: OpenClawPluginConfig,
 ): OpenClawHandle {
   const activeSessions = new Map<string, ActiveSession>();
+  // Per-session pending overrides applied at the next before_agent_start.
+  const pendingOverrides = new Map<
+    string,
+    { runId?: string; sessionId?: string; metadata?: Record<string, string> }
+  >();
 
-  const pluginConfig: Record<string, unknown> = {
+  const merged: Record<string, unknown> = {
     ...(api.pluginConfig ?? {}),
     ...configOverrides,
   };
+  const pluginConfig = merged as OpenClawPluginConfig & Record<string, unknown>;
+
   const debug =
     pluginConfig.debug === true || process.env.TCC_DEBUG === "true";
 
@@ -38,8 +103,10 @@ function registerHooks(
     log.warn("No TCC_API_KEY found. Set env var or plugin config. Disabled.");
     return {
       getRunId: () => null,
+      getRunIdForSession: () => null,
       setRunId: () => {},
       setMetadata: () => {},
+      setRunContext: () => {},
     };
   }
 
@@ -52,16 +119,17 @@ function registerHooks(
   log.info(`exporting runs to ${url}`);
 
   // -------------------------------------------------------------------
-  // Run ID + metadata state
+  // Global/default state
   // -------------------------------------------------------------------
   let lastRunId: string | null = null;
-  let nextRunId: string | null =
+  // Legacy one-shot: consumed by the next session that starts.
+  let legacyNextRunId: string | null =
     typeof pluginConfig.runId === "string" ? pluginConfig.runId : null;
-  const sessionId =
-    typeof pluginConfig.sessionId === "string" ? pluginConfig.sessionId : undefined;
-  let extraMetadata: Record<string, string> = {
-    ...((pluginConfig.metadata as Record<string, string>) ?? {}),
-  };
+  // Mutable defaults appended to every run (merged with callback-level overrides).
+  const globalDefaultMetadata: Record<string, string> = {};
+
+  const onRunStart = pluginConfig.onRunStart;
+  const onRunEnd = pluginConfig.onRunEnd;
 
   // -------------------------------------------------------------------
   // Stale session cleanup — flush sessions that never got an agent_end
@@ -75,16 +143,7 @@ function registerHooks(
         if (debug) log.info(`flushing stale session: ${key}`);
 
         sendToTcc(
-          {
-            framework: "openclaw",
-            runId: session.runId,
-            events: session.events,
-            stale: true,
-            ...(sessionId ? { sessionId } : {}),
-            ...(Object.keys(extraMetadata).length > 0
-              ? { metadata: { ...extraMetadata } }
-              : {}),
-          },
+          buildPayload(session, /* stale */ true),
           apiKey,
           url,
           debug,
@@ -96,26 +155,84 @@ function registerHooks(
         activeSessions.delete(key);
       }
     }
-  }, 5 * 60 * 1000); // check every 5 minutes
+  }, 5 * 60 * 1000);
 
   if (cleanupInterval.unref) cleanupInterval.unref();
 
-  // -------------------------------------------------------------------
-  // Helper: push a raw event into the session's event list
-  // -------------------------------------------------------------------
-  function pushEvent(hook: string, event: unknown, ctx: unknown): void {
-    const sessionKey = (ctx as any)?.sessionKey;
-    if (!sessionKey) return;
+  function buildPayload(
+    session: ActiveSession,
+    stale: boolean,
+  ): Record<string, unknown> {
+    // tcc.* keys are the canonical contract. User-supplied metadata goes
+    // through first; the plugin's authoritative runId/sessionId stamp last
+    // so there's a single source of truth.
+    const metadata: Record<string, unknown> = {
+      ...globalDefaultMetadata,
+      ...session.metadata,
+      "tcc.runId": session.runId,
+      ...(session.sessionId ? { "tcc.sessionId": session.sessionId } : {}),
+    };
+    return {
+      framework: "openclaw",
+      events: session.events,
+      metadata,
+      ...(stale ? { stale: true } : {}),
+    };
+  }
 
+  // -------------------------------------------------------------------
+  // Session lifecycle
+  // -------------------------------------------------------------------
+
+  function ensureSession(
+    sessionKey: string,
+    ctx: OpenClawRunContext,
+  ): ActiveSession {
     let session = activeSessions.get(sessionKey);
-    if (!session) {
-      const runId = nextRunId ?? crypto.randomUUID();
-      nextRunId = null;
-      lastRunId = runId;
-      session = { events: [], startedAt: Date.now(), runId };
-      activeSessions.set(sessionKey, session);
-      if (debug) log.info(`run started (runId: ${runId})`);
+    if (session) return session;
+
+    // Mint a fresh runId per turn. Legacy top-level runId (if present) wins
+    // ONLY the first time — same as before, preserved for backwards compat.
+    let runId: string;
+    if (legacyNextRunId) {
+      runId = legacyNextRunId;
+      legacyNextRunId = null;
+    } else {
+      runId = crypto.randomUUID();
     }
+
+    const defaultSessionId = resolveDefaultSessionId(pluginConfig.sessionId, ctx);
+    const defaultMetadata = resolveDefaultMetadata(pluginConfig.metadata, ctx);
+
+    session = {
+      events: [],
+      startedAt: Date.now(),
+      runId,
+      sessionId: defaultSessionId ?? ctx.sessionKey,
+      metadata: defaultMetadata,
+    };
+    activeSessions.set(sessionKey, session);
+
+    // Apply any pending setRunContext overrides queued before the session
+    // started.
+    const pending = pendingOverrides.get(sessionKey);
+    if (pending) {
+      if (pending.runId) session.runId = pending.runId;
+      if (pending.sessionId) session.sessionId = pending.sessionId;
+      if (pending.metadata) Object.assign(session.metadata, pending.metadata);
+      pendingOverrides.delete(sessionKey);
+    }
+
+    lastRunId = session.runId;
+    if (debug) log.info(`run started (runId: ${session.runId})`);
+    return session;
+  }
+
+  function pushEvent(hook: string, event: unknown, ctx: unknown): void {
+    const runCtx = toRunContext(ctx);
+    const sessionKey = runCtx.sessionKey;
+    if (!sessionKey) return;
+    const session = ensureSession(sessionKey, runCtx);
 
     session.events.push({
       hook,
@@ -126,8 +243,52 @@ function registerHooks(
   }
 
   // -------------------------------------------------------------------
-  // Hooks: collect raw events
+  // Hooks
   // -------------------------------------------------------------------
+
+  api.on("before_agent_start", async (event: any, ctx: any) => {
+    const runCtx = toRunContext(ctx);
+    const sessionKey = runCtx.sessionKey;
+    if (!sessionKey) return;
+
+    const session = ensureSession(sessionKey, runCtx);
+
+    if (onRunStart) {
+      const mutators = {
+        setRunId: (id: string) => {
+          session.runId = id;
+          lastRunId = id;
+        },
+        setSessionId: (id: string) => {
+          session.sessionId = id;
+        },
+        setMetadata: (meta: Record<string, unknown>) => {
+          for (const [k, v] of Object.entries(meta)) {
+            // Route tcc.* shortcuts into canonical session slots so they
+            // win at send time, regardless of which API the user picked.
+            if (k === "tcc.runId" && typeof v === "string") {
+              session.runId = v;
+              lastRunId = v;
+            } else if (k === "tcc.sessionId" && typeof v === "string") {
+              session.sessionId = v;
+            } else {
+              session.metadata[k] = v as string;
+            }
+          }
+        },
+      };
+      try {
+        await onRunStart({
+          runId: session.runId,
+          ctx: runCtx,
+          prompt: typeof event?.prompt === "string" ? event.prompt : "",
+          ...mutators,
+        });
+      } catch (err) {
+        log.warn(`onRunStart threw: ${err}`);
+      }
+    }
+  });
 
   api.on("llm_input", (event: any, ctx: any) => {
     pushEvent("llm_input", event, ctx);
@@ -150,33 +311,42 @@ function registerHooks(
   });
 
   api.on("agent_end", (event: any, ctx: any) => {
-    const sessionKey = ctx?.sessionKey;
+    const runCtx = toRunContext(ctx);
+    const sessionKey = runCtx.sessionKey;
     if (!sessionKey) return;
 
     pushEvent("agent_end", event, ctx);
 
-    // Defer sending to a microtask so llm_output (which fires on the
-    // same synchronous tick as agent_end) gets collected first.
-    queueMicrotask(() => {
+    // Defer send to a microtask so llm_output (on the same synchronous tick)
+    // is collected first.
+    queueMicrotask(async () => {
       const session = activeSessions.get(sessionKey);
       if (!session) return;
 
       if (debug)
-        log.info(`agent_end — sending ${session.events.length} events (runId: ${session.runId})`);
+        log.info(
+          `agent_end — sending ${session.events.length} events (runId: ${session.runId})`,
+        );
 
-      const payload: Record<string, unknown> = {
-        framework: "openclaw",
-        runId: session.runId,
-        events: session.events,
-        ...(sessionId ? { sessionId } : {}),
-        ...(Object.keys(extraMetadata).length > 0
-          ? { metadata: { ...extraMetadata } }
-          : {}),
-      };
+      const payload = buildPayload(session, false);
 
       sendToTcc(payload, apiKey, url, debug, log).catch((err) => {
         log.warn(`failed to send events: ${err}`);
       });
+
+      if (onRunEnd) {
+        try {
+          await onRunEnd({
+            runId: session.runId,
+            ctx: runCtx,
+            success: event?.success !== false,
+            sessionId: session.sessionId,
+            metadata: { ...globalDefaultMetadata, ...session.metadata },
+          });
+        } catch (err) {
+          log.warn(`onRunEnd threw: ${err}`);
+        }
+      }
 
       activeSessions.delete(sessionKey);
     });
@@ -184,11 +354,38 @@ function registerHooks(
 
   return {
     getRunId: () => lastRunId,
+    getRunIdForSession: (sessionKey: string) =>
+      activeSessions.get(sessionKey)?.runId ?? null,
     setRunId: (id: string) => {
-      nextRunId = id;
+      legacyNextRunId = id;
     },
     setMetadata: (meta: Record<string, string>) => {
-      Object.assign(extraMetadata, meta);
+      Object.assign(globalDefaultMetadata, meta);
+    },
+    setRunContext: (
+      sessionKey: string,
+      ctx: {
+        runId?: string;
+        sessionId?: string;
+        metadata?: Record<string, string>;
+      },
+    ) => {
+      const existing = activeSessions.get(sessionKey);
+      if (existing) {
+        if (ctx.runId) {
+          existing.runId = ctx.runId;
+          lastRunId = ctx.runId;
+        }
+        if (ctx.sessionId) existing.sessionId = ctx.sessionId;
+        if (ctx.metadata) Object.assign(existing.metadata, ctx.metadata);
+        return;
+      }
+      const pending = pendingOverrides.get(sessionKey) ?? {};
+      if (ctx.runId) pending.runId = ctx.runId;
+      if (ctx.sessionId) pending.sessionId = ctx.sessionId;
+      if (ctx.metadata)
+        pending.metadata = { ...(pending.metadata ?? {}), ...ctx.metadata };
+      pendingOverrides.set(sessionKey, pending);
     },
   };
 }
@@ -196,28 +393,12 @@ function registerHooks(
 /**
  * Full OpenClaw plugin object — install via `openclaw plugins install`
  * and configure in `openclaw.json` under `plugins.entries`.
- *
- * @example
- * ```json
- * {
- *   "plugins": {
- *     "allow": ["@contextcompany/openclaw"],
- *     "entries": {
- *       "@contextcompany/openclaw": {
- *         "enabled": true,
- *         "config": {
- *           "apiKey": "${TCC_API_KEY}"
- *         }
- *       }
- *     }
- *   }
- * }
- * ```
  */
 const plugin = {
   id: "openclaw",
   name: "The Context Company",
-  description: "Agent observability — captures LLM calls, tool executions, and agent lifecycle events",
+  description:
+    "Agent observability — captures LLM calls, tool executions, and agent lifecycle events",
   register(api: any) {
     registerHooks(api);
   },
@@ -232,7 +413,14 @@ export default plugin;
  * ```ts
  * import { register } from "@contextcompany/openclaw";
  * export default async function (api) {
- *   register(api, { apiKey: "tcc_...", debug: true });
+ *   const handle = register(api, {
+ *     onRunStart: ({ runId, ctx, setMetadata }) => {
+ *       setMetadata({ channel: ctx.channelId ?? "unknown" });
+ *     },
+ *     onRunEnd: ({ runId }) => {
+ *       // stash runId for feedback submission
+ *     },
+ *   });
  * }
  * ```
  */

--- a/packages/ts/openclaw/src/plugin.ts
+++ b/packages/ts/openclaw/src/plugin.ts
@@ -8,14 +8,14 @@
  */
 
 import { getTCCApiKey, getTCCUrl } from "@contextcompany/api";
-import type { ActiveSession, OpenClawPluginConfig } from "./types.js";
-export type { OpenClawPluginConfig } from "./types.js";
+import type { ActiveSession, OpenClawHandle, OpenClawPluginConfig } from "./types.js";
+export type { OpenClawPluginConfig, OpenClawHandle } from "./types.js";
 import { safeClone, sendToTcc } from "./transport.js";
 
 function registerHooks(
   api: any,
   configOverrides?: OpenClawPluginConfig,
-): void {
+): OpenClawHandle {
   const activeSessions = new Map<string, ActiveSession>();
 
   const pluginConfig: Record<string, unknown> = {
@@ -36,7 +36,11 @@ function registerHooks(
 
   if (!apiKey) {
     log.warn("No TCC_API_KEY found. Set env var or plugin config. Disabled.");
-    return;
+    return {
+      getRunId: () => null,
+      setRunId: () => {},
+      setMetadata: () => {},
+    };
   }
 
   const url =
@@ -46,6 +50,18 @@ function registerHooks(
     getTCCUrl("/v1/openclaw", apiKey);
 
   log.info(`exporting runs to ${url}`);
+
+  // -------------------------------------------------------------------
+  // Run ID + metadata state
+  // -------------------------------------------------------------------
+  let lastRunId: string | null = null;
+  let nextRunId: string | null =
+    typeof pluginConfig.runId === "string" ? pluginConfig.runId : null;
+  const sessionId =
+    typeof pluginConfig.sessionId === "string" ? pluginConfig.sessionId : undefined;
+  let extraMetadata: Record<string, string> = {
+    ...((pluginConfig.metadata as Record<string, string>) ?? {}),
+  };
 
   // -------------------------------------------------------------------
   // Stale session cleanup — flush sessions that never got an agent_end
@@ -59,7 +75,16 @@ function registerHooks(
         if (debug) log.info(`flushing stale session: ${key}`);
 
         sendToTcc(
-          { framework: "openclaw", events: session.events, stale: true },
+          {
+            framework: "openclaw",
+            runId: session.runId,
+            events: session.events,
+            stale: true,
+            ...(sessionId ? { sessionId } : {}),
+            ...(Object.keys(extraMetadata).length > 0
+              ? { metadata: { ...extraMetadata } }
+              : {}),
+          },
           apiKey,
           url,
           debug,
@@ -84,8 +109,12 @@ function registerHooks(
 
     let session = activeSessions.get(sessionKey);
     if (!session) {
-      session = { events: [], startedAt: Date.now() };
+      const runId = nextRunId ?? crypto.randomUUID();
+      nextRunId = null;
+      lastRunId = runId;
+      session = { events: [], startedAt: Date.now(), runId };
       activeSessions.set(sessionKey, session);
+      if (debug) log.info(`run started (runId: ${runId})`);
     }
 
     session.events.push({
@@ -133,11 +162,16 @@ function registerHooks(
       if (!session) return;
 
       if (debug)
-        log.info(`agent_end — sending ${session.events.length} events`);
+        log.info(`agent_end — sending ${session.events.length} events (runId: ${session.runId})`);
 
-      const payload = {
+      const payload: Record<string, unknown> = {
         framework: "openclaw",
+        runId: session.runId,
         events: session.events,
+        ...(sessionId ? { sessionId } : {}),
+        ...(Object.keys(extraMetadata).length > 0
+          ? { metadata: { ...extraMetadata } }
+          : {}),
       };
 
       sendToTcc(payload, apiKey, url, debug, log).catch((err) => {
@@ -147,6 +181,16 @@ function registerHooks(
       activeSessions.delete(sessionKey);
     });
   });
+
+  return {
+    getRunId: () => lastRunId,
+    setRunId: (id: string) => {
+      nextRunId = id;
+    },
+    setMetadata: (meta: Record<string, string>) => {
+      Object.assign(extraMetadata, meta);
+    },
+  };
 }
 
 /**
@@ -195,6 +239,6 @@ export default plugin;
 export function register(
   api: any,
   configOverrides?: OpenClawPluginConfig,
-): void {
-  registerHooks(api, configOverrides);
+): OpenClawHandle {
+  return registerHooks(api, configOverrides);
 }

--- a/packages/ts/openclaw/src/plugin.ts
+++ b/packages/ts/openclaw/src/plugin.ts
@@ -215,7 +215,7 @@ function registerHooks(
  * ```
  */
 const plugin = {
-  id: "@contextcompany/openclaw",
+  id: "openclaw",
   name: "The Context Company",
   description: "Agent observability — captures LLM calls, tool executions, and agent lifecycle events",
   register(api: any) {

--- a/packages/ts/openclaw/src/types.ts
+++ b/packages/ts/openclaw/src/types.ts
@@ -6,35 +6,97 @@ export type RawEvent = {
   context: Record<string, unknown>;
 };
 
+/** Subset of OpenClaw's PluginHookAgentContext exposed to user callbacks. */
+export type OpenClawRunContext = {
+  agentId?: string;
+  sessionKey?: string;
+  sessionId?: string;
+  channelId?: string;
+  workspaceDir?: string;
+  trigger?: string;
+};
+
 /** In-flight session accumulating events before send. */
 export type ActiveSession = {
   events: RawEvent[];
   startedAt: number;
   runId: string;
+  sessionId?: string;
+  metadata: Record<string, string>;
 };
+
+/** Mutation API passed into onRunStart. Changes apply to this run only. */
+export type OpenClawRunMutators = {
+  /** Override the auto-minted run ID for this run. Must be a valid UUID to be usable with feedback/metadata endpoints. */
+  setRunId: (id: string) => void;
+  /** Override the session ID for this run. */
+  setSessionId: (id: string) => void;
+  /** Merge metadata into this run's payload (shallow merge). */
+  setMetadata: (meta: Record<string, string>) => void;
+};
+
+/** Called at before_agent_start with the run context and mutation API. */
+export type OpenClawRunStartHandler = (info: {
+  runId: string;
+  ctx: OpenClawRunContext;
+  prompt: string;
+} & OpenClawRunMutators) => void | Promise<void>;
+
+/** Called at agent_end with the finalized run info. */
+export type OpenClawRunEndHandler = (info: {
+  runId: string;
+  ctx: OpenClawRunContext;
+  success: boolean;
+  sessionId?: string;
+  metadata: Record<string, string>;
+}) => void | Promise<void>;
+
+/** Default providers resolved once per session. */
+export type OpenClawDefaultSessionId =
+  | string
+  | ((ctx: OpenClawRunContext) => string | undefined);
+export type OpenClawDefaultMetadata =
+  | Record<string, string>
+  | ((ctx: OpenClawRunContext) => Record<string, string>);
 
 /** Configuration for the TCC OpenClaw plugin. */
 export type OpenClawPluginConfig = {
   /** TCC API key. Falls back to TCC_API_KEY env var. */
   apiKey?: string;
-  /** TCC ingestion endpoint. Falls back to TCC_URL env var, then auto-detected from key prefix. */
+  /** TCC ingestion endpoint. Falls back to TCC_BASE_URL env var, then auto-detected from key prefix. */
   endpoint?: string;
   /** Enable debug logging. Falls back to TCC_DEBUG env var. */
   debug?: boolean;
-  /** Explicit run ID. If not set, a random UUID is generated per agent run. */
+
+  /**
+   * Explicit run ID for the FIRST run only (legacy). For per-run IDs use
+   * `onRunStart`'s `setRunId`, or call `handle.setRunContext(sessionKey, {...})`.
+   */
   runId?: string;
-  /** Session ID to group multiple runs in the same conversation. */
-  sessionId?: string;
-  /** Arbitrary key-value metadata attached to every run. */
-  metadata?: Record<string, string>;
+  /** Default session ID applied to every run (falls back to ctx.sessionKey). */
+  sessionId?: OpenClawDefaultSessionId;
+  /** Default metadata merged into every run. */
+  metadata?: OpenClawDefaultMetadata;
+
+  /** Called at before_agent_start; lets you override runId/sessionId/metadata per run. */
+  onRunStart?: OpenClawRunStartHandler;
+  /** Called at agent_end; lets you attach feedback / log the runId. */
+  onRunEnd?: OpenClawRunEndHandler;
 };
 
 /** Handle returned by `register()` for run ID and metadata access. */
 export type OpenClawHandle = {
-  /** Returns the run ID of the most recently completed (or in-progress) run. */
+  /** Returns the run ID of the most recently completed (or in-progress) run. For concurrency-safe lookups, use `getRunIdForSession`. */
   getRunId: () => string | null;
-  /** Sets the run ID that will be used for the next run. */
+  /** Per-session run ID lookup (concurrency-safe). */
+  getRunIdForSession: (sessionKey: string) => string | null;
+  /** Legacy: set the runId for the NEXT new session (consumed once). */
   setRunId: (id: string) => void;
-  /** Merges additional metadata for subsequent runs. */
+  /** Legacy: merge metadata into the global default for subsequent runs. */
   setMetadata: (meta: Record<string, string>) => void;
+  /** Per-session override: apply runId/sessionId/metadata to an in-flight or future session. */
+  setRunContext: (
+    sessionKey: string,
+    ctx: { runId?: string; sessionId?: string; metadata?: Record<string, string> },
+  ) => void;
 };

--- a/packages/ts/openclaw/src/types.ts
+++ b/packages/ts/openclaw/src/types.ts
@@ -10,6 +10,7 @@ export type RawEvent = {
 export type ActiveSession = {
   events: RawEvent[];
   startedAt: number;
+  runId: string;
 };
 
 /** Configuration for the TCC OpenClaw plugin. */
@@ -20,4 +21,20 @@ export type OpenClawPluginConfig = {
   endpoint?: string;
   /** Enable debug logging. Falls back to TCC_DEBUG env var. */
   debug?: boolean;
+  /** Explicit run ID. If not set, a random UUID is generated per agent run. */
+  runId?: string;
+  /** Session ID to group multiple runs in the same conversation. */
+  sessionId?: string;
+  /** Arbitrary key-value metadata attached to every run. */
+  metadata?: Record<string, string>;
+};
+
+/** Handle returned by `register()` for run ID and metadata access. */
+export type OpenClawHandle = {
+  /** Returns the run ID of the most recently completed (or in-progress) run. */
+  getRunId: () => string | null;
+  /** Sets the run ID that will be used for the next run. */
+  setRunId: (id: string) => void;
+  /** Merges additional metadata for subsequent runs. */
+  setMetadata: (meta: Record<string, string>) => void;
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10743,7 +10743,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -10765,7 +10765,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.1(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3


### PR DESCRIPTION
## 🎯 Changes

Users of the openclaw plugin previously had no way to access the run ID or attach metadata to runs, making it impossible to submit feedback or correlate runs. This PR:

- `register()` now returns an `OpenClawHandle` with `getRunId()`, `setRunId()`, and `setMetadata()` methods
- Adds `runId`, `sessionId`, and `metadata` config options to `OpenClawPluginConfig`
- Generates a fresh UUID per agent run on the client side and includes it in the payload, fixing the duplicate runId bug caused by OpenClaw's persistent `context.runId`
- Updates the plugin JSON schema and README with the new API

> **Note:** The server-side ingest converter (`packages/ingest/src/converters/OpenClaw.ts`) also needs to be updated to prefer `payload.runId` over `context.runId`. That change lives in the `context` repo.

## ✅ Checklist

- [x] I have followed the steps listed in the Contributing guide.
- [x] If necessary, I have added documentation related to the changes made.
- [ ] If applicable, I have added or updated the tests related to the changes made.

## 🔒 Related Issues

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Modifies the OpenClaw client payload shape and session/run lifecycle handling (new per-turn UUIDs, thread-scoped session IDs, and async callbacks), which could impact ingestion correlation and existing integrations if assumptions about IDs/metadata change.
> 
> **Overview**
> Adds per-turn observability context to the `@contextcompany/openclaw` plugin: each agent turn now mints a fresh UUID `runId`, includes canonical `tcc.runId`/`tcc.sessionId` inside `metadata`, and supports thread-scoped session grouping by deriving `sessionId` from `before_dispatch` (falling back to `ctx.sessionKey`).
> 
> Introduces a user-facing per-run API: `register()` now returns an `OpenClawHandle` with `getRunIdForSession()` and `setRunContext()`, plus `onRunStart`/`onRunEnd` callbacks with mutators to override `runId`/`sessionId`/`metadata` per turn; `sessionId` and `metadata` config options can also be functions of the run context.
> 
> Updates plugin schema/docs/examples accordingly, changes the plugin `id` to `openclaw`, and re-exports `submitFeedback` to support feedback submission using captured run IDs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit baf37cac2375196624a7773b75e0a23589ac1a71. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->