### PR TITLE
ci(release-ts): use corepack to install npm

### DIFF
--- a/.github/workflows/release-ts.yml
+++ b/.github/workflows/release-ts.yml
@@ -33,10 +33,13 @@ jobs:
           registry-url: "https://registry.npmjs.org"
 
       - name: Upgrade npm for OIDC trusted publishing
-        # Node 22's bundled npm can have a broken self-upgrade path
-        # ("Cannot find module 'promise-retry'"). --force skips the broken
-        # dep check during install. Pin to @11 to avoid future regressions.
-        run: npm install -g --force npm@11
+        # Node 22's bundled npm can itself be corrupted ("Cannot find module
+        # 'promise-retry'") and can't even run `npm install` on itself.
+        # Use corepack to bypass the broken bundled npm entirely.
+        run: |
+          corepack enable npm
+          corepack prepare npm@11.5.2 --activate
+          npm --version
 
       - run: pnpm install --frozen-lockfile
 


### PR DESCRIPTION
Bundled npm on Node 22 images is corrupted (`Cannot find module 'promise-retry'`), so it can't run `npm install -g npm@latest` on itself. Corepack bypasses the broken bundled npm entirely.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that only affects the release workflow environment setup. Main potential impact is if `corepack prepare` fails or pins an npm version incompatible with the job.
> 
> **Overview**
> Updates the TypeScript release GitHub Actions workflow to stop self-upgrading npm via `npm install -g` and instead use Corepack (`corepack enable/prepare`) to activate a pinned `npm@11.5.2`.
> 
> This is intended to bypass corrupted bundled npm on Node 22 runners and make the OIDC trusted publishing step more reliable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74fa18b28b92b93d3f0678aa3c61d59357f59d05. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->