### PR TITLE
ci(release-ts): relax corepack strict mode

### DIFF
--- a/.github/workflows/release-ts.yml
+++ b/.github/workflows/release-ts.yml
@@ -33,10 +33,13 @@ jobs:
           registry-url: "https://registry.npmjs.org"
 
       - name: Upgrade npm for OIDC trusted publishing
-        # Node 22's bundled npm can have a broken self-upgrade path
-        # ("Cannot find module 'promise-retry'"). --force skips the broken
-        # dep check during install. Pin to @11 to avoid future regressions.
-        run: npm install -g --force npm@11
+        # Node 22's bundled npm can itself be corrupted ("Cannot find module
+        # 'promise-retry'") and can't even run `npm install` on itself.
+        # Use corepack to bypass the broken bundled npm entirely.
+        run: |
+          corepack enable npm
+          corepack prepare npm@11.5.2 --activate
+          npm --version
 
       - run: pnpm install --frozen-lockfile
 

--- a/.github/workflows/release-ts.yml
+++ b/.github/workflows/release-ts.yml
@@ -16,6 +16,10 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-latest
+    env:
+      # Allow npm to run even though root package.json pins pnpm. Needed so
+      # changesets can invoke `npm publish` inside each package.
+      COREPACK_ENABLE_STRICT: "0"
 
     steps:
       - uses: actions/checkout@v4
@@ -35,7 +39,7 @@ jobs:
       - name: Upgrade npm for OIDC trusted publishing
         # Node 22's bundled npm can itself be corrupted ("Cannot find module
         # 'promise-retry'") and can't even run `npm install` on itself.
-        # Use corepack to bypass the broken bundled npm entirely.
+        # Use corepack to bypass the broken bundled npm.
         run: |
           corepack enable npm
           corepack prepare npm@11.5.2 --activate


### PR DESCRIPTION
Follow-up: after switching to corepack for npm install, corepack refuses to run npm because root package.json pins pnpm. Set COREPACK_ENABLE_STRICT=0 at job level so changesets can publish via npm.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the TypeScript release workflow’s npm bootstrapping and corepack settings, which can impact package publishing reliability. Scope is limited to CI configuration but affects release automation.
> 
> **Overview**
> Updates the TypeScript release GitHub Action to **relax corepack strict mode** (`COREPACK_ENABLE_STRICT=0`) so Changesets can run `npm publish` even though the repo pins `pnpm`.
> 
> Also switches the npm “upgrade” step to **install npm via corepack** (pinning `npm@11.5.2`) to work around broken bundled npm in Node 22, instead of attempting `npm install -g`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c04fa0fdb761bafebdbe14d702dc4b79bdd06091. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->