### PR TITLE
ci(release-ts): set COREPACK_ENABLE_STRICT=0

### DIFF
--- a/.github/workflows/release-ts.yml
+++ b/.github/workflows/release-ts.yml
@@ -16,6 +16,10 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-latest
+    env:
+      # Allow npm to run even though root package.json pins pnpm. Needed so
+      # changesets can invoke `npm publish` inside each package.
+      COREPACK_ENABLE_STRICT: "0"
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Corepack refuses to run npm while root package.json pins pnpm. Set the env var at job level so changesets can publish.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that tweaks environment settings for the release workflow; main impact is on npm/pnpm resolution during publishing.
> 
> **Overview**
> Updates the TypeScript release GitHub Actions workflow to set `COREPACK_ENABLE_STRICT=0` at the job level so `changesets` can invoke `npm publish` even though the repo is pinned to `pnpm` via Corepack.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 474a0926f75e8894be12ad9a329a32e679c6522b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->