### PR TITLE
feat(python): add Claude Agent SDK support

### DIFF
--- a/examples/claude-agent-sdk-python/.env.example
+++ b/examples/claude-agent-sdk-python/.env.example
@@ -1,0 +1,7 @@
+# Anthropic API Key (Required)
+# Get your API key from: https://console.anthropic.com/
+ANTHROPIC_API_KEY=sk-ant-your_api_key_here
+
+# The Context Company API Key (Required)
+# Get yours at https://thecontext.company
+TCC_API_KEY=your_tcc_api_key_here

--- a/examples/claude-agent-sdk-python/.gitignore
+++ b/examples/claude-agent-sdk-python/.gitignore
@@ -1,0 +1,5 @@
+venv/
+__pycache__/
+*.pyc
+.env
+*.egg-info/

--- a/examples/claude-agent-sdk-python/README.md
+++ b/examples/claude-agent-sdk-python/README.md
@@ -1,0 +1,74 @@
+# Claude Agent SDK Python Example with TCC Instrumentation
+
+A simple example demonstrating the Claude Agent SDK for Python with The Context Company telemetry.
+
+## Features
+
+- **TCC instrumentation** for automatic telemetry collection
+- **Interactive conversation** with session tracking
+- **Feedback submission** with thumbs up/down
+- **Single query mode** for scripting
+
+## Setup
+
+1. **Create a virtual environment**:
+   ```bash
+   python -m venv venv
+   source venv/bin/activate
+   ```
+
+2. **Install dependencies**:
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+3. **Configure environment**:
+   Copy `.env.example` to `.env` and add your API keys:
+   ```bash
+   cp .env.example .env
+   ```
+
+4. **Run the example**:
+   ```bash
+   python main.py
+   ```
+
+   Or run a single query:
+   ```bash
+   python main.py "What is 2 + 2?"
+   ```
+
+## Usage
+
+Ask questions naturally:
+- "What is the capital of France?"
+- "Explain quantum computing in simple terms"
+- "Write a haiku about programming"
+
+Give feedback on responses:
+- Type `up` for thumbs up 👍
+- Type `down` for thumbs down 👎
+- Type `exit` to quit
+
+## TCC Instrumentation
+
+The example shows how to:
+1. Create an instrumented agent with `instrument_claude_agent()`
+2. Pass TCC configuration via `TCCConfig` in each `query()` call
+3. Submit user feedback with `submit_feedback()`
+
+Each conversation has a unique `session_id`, and each query has a unique `run_id` for tracking in TCC.
+
+## Debug Mode
+
+Enable verbose TCC debug logging:
+
+```bash
+TCC_DEBUG=true python main.py
+```
+
+Or pass `debug=True` in the `TCCConfig`:
+
+```python
+tcc_config=TCCConfig(run_id="...", debug=True)
+```

--- a/examples/claude-agent-sdk-python/README.md
+++ b/examples/claude-agent-sdk-python/README.md
@@ -5,6 +5,7 @@ A simple example demonstrating the Claude Agent SDK for Python with The Context 
 ## Features
 
 - **TCC instrumentation** for automatic telemetry collection
+- **Custom MCP tool** (`get_user_info`) served in-process via `create_sdk_mcp_server`
 - **Interactive conversation** with session tracking
 - **Feedback submission** with thumbs up/down
 - **Single query mode** for scripting
@@ -40,14 +41,18 @@ A simple example demonstrating the Claude Agent SDK for Python with The Context 
 
 ## Usage
 
-Ask questions naturally:
-- "What is the capital of France?"
-- "Explain quantum computing in simple terms"
-- "Write a haiku about programming"
+The example exposes a custom `get_user_info` tool over an in-process MCP server. Claude can call it to answer questions about the mock users (`user-001`, `user-002`, `user-003`).
+
+Try prompts like:
+- "Tell me about user-001"
+- "What plan is Bob on?"
+- "Compare user-002 and user-003"
+
+You can also ask plain questions. Claude will skip the tool when it isn't relevant.
 
 Give feedback on responses:
-- Type `up` for thumbs up 👍
-- Type `down` for thumbs down 👎
+- Type `up` for thumbs up
+- Type `down` for thumbs down
 - Type `exit` to quit
 
 ## TCC Instrumentation

--- a/examples/claude-agent-sdk-python/main.py
+++ b/examples/claude-agent-sdk-python/main.py
@@ -1,0 +1,202 @@
+"""
+Claude Agent SDK Example with The Context Company (TCC) Observability
+
+This example demonstrates the Claude Agent SDK for Python instrumented
+with TCC for full observability of agent runs.  It mirrors the TypeScript
+example in ``examples/claude-agent-sdk/``.
+
+Features:
+    - Interactive conversation with Claude via the Agent SDK
+    - TCC instrumentation for telemetry collection
+    - Session tracking across multiple queries
+    - Feedback submission (thumbs up / thumbs down)
+"""
+
+import asyncio
+import os
+import sys
+import uuid
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+# TCC: Import and initialise Claude Agent SDK instrumentation
+from contextcompany.claude import instrument_claude_agent, TCCConfig
+from contextcompany import submit_feedback
+
+# Create the instrumented agent — call once at startup
+agent = instrument_claude_agent()
+
+
+# ============================================================================
+# Main Application
+# ============================================================================
+
+
+async def run_single_query(query: str) -> None:
+    """Run a single query and exit."""
+    from claude_agent_sdk import (
+        AssistantMessage,
+        ClaudeAgentOptions,
+        ResultMessage,
+        TextBlock,
+    )
+
+    print(f"\nRunning query: {query}\n")
+
+    run_id = str(uuid.uuid4())
+    print(f"[Run ID: {run_id}]")
+
+    options = ClaudeAgentOptions(
+        system_prompt=(
+            "You are a helpful assistant. Answer the user's questions "
+            "clearly and concisely."
+        ),
+        max_turns=3,
+    )
+
+    try:
+        async for message in agent.query(
+            prompt=query,
+            options=options,
+            tcc_config=TCCConfig(
+                run_id=run_id,
+                metadata={"environment": "development"},
+            ),
+        ):
+            if isinstance(message, AssistantMessage):
+                for block in message.content:
+                    if isinstance(block, TextBlock):
+                        print(f"Claude: {block.text}")
+            elif isinstance(message, ResultMessage):
+                if hasattr(message, "total_cost_usd") and message.total_cost_usd:
+                    print(f"\n[Cost: ${message.total_cost_usd:.4f}]")
+    except Exception as e:
+        print(f"\nError: {e}\n")
+        sys.exit(1)
+
+
+async def run_interactive() -> None:
+    """Run the agent in interactive mode with TCC tracking."""
+    from claude_agent_sdk import (
+        AssistantMessage,
+        ClaudeAgentOptions,
+        ResultMessage,
+        TextBlock,
+    )
+
+    print("\n" + "=" * 60)
+    print("Claude Agent SDK Example with TCC Instrumentation")
+    print("=" * 60)
+    print("\nAsk Claude anything!")
+    print("\nCommands:")
+    print("  Type your question naturally")
+    print("  Type 'up' to give thumbs up feedback on the last response")
+    print("  Type 'down' to give thumbs down feedback")
+    print("  Type 'exit' or 'quit' to end the session")
+    print("=" * 60 + "\n")
+
+    # TCC: Generate a unique session ID to track this conversation
+    session_id = str(uuid.uuid4())
+    print(f"[Session ID: {session_id}]\n")
+
+    previous_run_id: str | None = None
+
+    while True:
+        try:
+            user_input = input("You: ").strip()
+
+            if not user_input:
+                continue
+
+            if user_input.lower() in ("exit", "quit", "q"):
+                print("\n👋 Goodbye!\n")
+                break
+
+            # Handle feedback commands
+            if user_input.lower() in ("up", "down"):
+                if previous_run_id:
+                    score = (
+                        "thumbs_up" if user_input.lower() == "up" else "thumbs_down"
+                    )
+                    emoji = "👍" if score == "thumbs_up" else "👎"
+                    print(f"\n{emoji} Submitting {score} feedback...")
+                    success = submit_feedback(
+                        run_id=previous_run_id, score=score
+                    )
+                    print(
+                        "✅ Feedback submitted!\n"
+                        if success
+                        else "❌ Failed to submit feedback\n"
+                    )
+                else:
+                    print("\n⚠️  No previous run to give feedback on\n")
+                continue
+
+            # TCC: Generate a unique run_id for this specific query
+            current_run_id = str(uuid.uuid4())
+            print(f"\n[Run ID: {current_run_id}]")
+            print("\nAssistant:")
+
+            options = ClaudeAgentOptions(
+                system_prompt=(
+                    "You are a helpful assistant. Answer the user's "
+                    "questions clearly and concisely."
+                ),
+                max_turns=5,
+            )
+
+            # TCC: Query with instrumentation — telemetry is sent automatically
+            async for message in agent.query(
+                prompt=user_input,
+                options=options,
+                tcc_config=TCCConfig(
+                    run_id=current_run_id,
+                    session_id=session_id,
+                    metadata={
+                        "environment": "development",
+                    },
+                ),
+            ):
+                if isinstance(message, AssistantMessage):
+                    for block in message.content:
+                        if isinstance(block, TextBlock):
+                            print(block.text)
+                elif isinstance(message, ResultMessage):
+                    if (
+                        hasattr(message, "total_cost_usd")
+                        and message.total_cost_usd
+                    ):
+                        print(f"\n[Cost: ${message.total_cost_usd:.4f}]")
+
+            previous_run_id = current_run_id
+            print()
+
+        except KeyboardInterrupt:
+            print("\n\n👋 Goodbye!\n")
+            break
+        except Exception as e:
+            print(f"\nError: {e}\n")
+
+
+async def main() -> None:
+    if not os.getenv("ANTHROPIC_API_KEY"):
+        print("Error: ANTHROPIC_API_KEY environment variable is not set")
+        print("Get your API key from: https://console.anthropic.com/")
+        sys.exit(1)
+
+    if not os.getenv("TCC_API_KEY"):
+        print("Error: TCC_API_KEY environment variable is not set")
+        print("Get your API key from: https://thecontext.company")
+        sys.exit(1)
+
+    if len(sys.argv) > 1:
+        query = " ".join(sys.argv[1:])
+        await run_single_query(query)
+    else:
+        await run_interactive()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/claude-agent-sdk-python/main.py
+++ b/examples/claude-agent-sdk-python/main.py
@@ -7,6 +7,7 @@ example in ``examples/claude-agent-sdk/``.
 
 Features:
     - Interactive conversation with Claude via the Agent SDK
+    - Custom MCP tool (get_user_info) served in-process via create_sdk_mcp_server
     - TCC instrumentation for telemetry collection
     - Session tracking across multiple queries
     - Feedback submission (thumbs up / thumbs down)
@@ -16,6 +17,7 @@ import asyncio
 import os
 import sys
 import uuid
+from typing import Any
 
 from dotenv import load_dotenv
 
@@ -25,8 +27,83 @@ load_dotenv()
 from contextcompany.claude import instrument_claude_agent, TCCConfig
 from contextcompany import submit_feedback
 
+# Claude Agent SDK: tool + MCP server factory for custom tools
+from claude_agent_sdk import tool, create_sdk_mcp_server
+
 # Create the instrumented agent — call once at startup
 agent = instrument_claude_agent()
+
+
+# ============================================================================
+# Custom MCP Tool: get_user_info
+# ============================================================================
+
+# Mock user database — mirrors the TypeScript example
+USERS: dict[str, dict[str, str]] = {
+    "user-001": {"name": "Alice Johnson", "email": "alice@example.com", "plan": "pro"},
+    "user-002": {"name": "Bob Smith", "email": "bob@example.com", "plan": "free"},
+    "user-003": {"name": "Carol White", "email": "carol@example.com", "plan": "enterprise"},
+}
+
+
+@tool(
+    "get_user_info",
+    "Get user information by user ID",
+    {"user_id": str},
+)
+async def get_user_info(args: dict[str, Any]) -> dict[str, Any]:
+    """Return user record as an MCP tool result."""
+    user = USERS.get(args["user_id"])
+
+    if not user:
+        return {
+            "content": [
+                {"type": "text", "text": f"User {args['user_id']} not found"}
+            ]
+        }
+
+    return {
+        "content": [
+            {
+                "type": "text",
+                "text": (
+                    f"User: {user['name']}\n"
+                    f"Email: {user['email']}\n"
+                    f"Plan: {user['plan']}"
+                ),
+            }
+        ]
+    }
+
+
+# In-process MCP server exposing the custom tool
+user_mcp_server = create_sdk_mcp_server(
+    name="user-agent",
+    version="1.0.0",
+    tools=[get_user_info],
+)
+
+
+SYSTEM_PROMPT = (
+    "You are a helpful assistant. Use the get_user_info tool to answer "
+    "questions about users. Available users are user-001, user-002, user-003."
+)
+
+
+# ============================================================================
+# Message printing helpers
+# ============================================================================
+
+
+def _print_assistant_blocks(message: Any) -> None:
+    """Print text blocks and surface tool-use blocks from an AssistantMessage."""
+    from claude_agent_sdk import TextBlock, ToolUseBlock
+
+    for block in message.content:
+        if isinstance(block, TextBlock):
+            print(block.text)
+        elif isinstance(block, ToolUseBlock):
+            print(f"  🔧 Tool call: {block.name}({block.input})")
 
 
 # ============================================================================
@@ -40,7 +117,6 @@ async def run_single_query(query: str) -> None:
         AssistantMessage,
         ClaudeAgentOptions,
         ResultMessage,
-        TextBlock,
     )
 
     print(f"\nRunning query: {query}\n")
@@ -49,11 +125,10 @@ async def run_single_query(query: str) -> None:
     print(f"[Run ID: {run_id}]")
 
     options = ClaudeAgentOptions(
-        system_prompt=(
-            "You are a helpful assistant. Answer the user's questions "
-            "clearly and concisely."
-        ),
-        max_turns=3,
+        system_prompt=SYSTEM_PROMPT,
+        mcp_servers={"users": user_mcp_server},
+        permission_mode="bypassPermissions",
+        max_turns=5,
     )
 
     try:
@@ -66,9 +141,7 @@ async def run_single_query(query: str) -> None:
             ),
         ):
             if isinstance(message, AssistantMessage):
-                for block in message.content:
-                    if isinstance(block, TextBlock):
-                        print(f"Claude: {block.text}")
+                _print_assistant_blocks(message)
             elif isinstance(message, ResultMessage):
                 if hasattr(message, "total_cost_usd") and message.total_cost_usd:
                     print(f"\n[Cost: ${message.total_cost_usd:.4f}]")
@@ -83,13 +156,12 @@ async def run_interactive() -> None:
         AssistantMessage,
         ClaudeAgentOptions,
         ResultMessage,
-        TextBlock,
     )
 
     print("\n" + "=" * 60)
     print("Claude Agent SDK Example with TCC Instrumentation")
     print("=" * 60)
-    print("\nAsk Claude anything!")
+    print("\nAsk Claude about users (user-001, user-002, user-003) or anything else.")
     print("\nCommands:")
     print("  Type your question naturally")
     print("  Type 'up' to give thumbs up feedback on the last response")
@@ -111,7 +183,7 @@ async def run_interactive() -> None:
                 continue
 
             if user_input.lower() in ("exit", "quit", "q"):
-                print("\n👋 Goodbye!\n")
+                print("\n Goodbye!\n")
                 break
 
             # Handle feedback commands
@@ -140,10 +212,9 @@ async def run_interactive() -> None:
             print("\nAssistant:")
 
             options = ClaudeAgentOptions(
-                system_prompt=(
-                    "You are a helpful assistant. Answer the user's "
-                    "questions clearly and concisely."
-                ),
+                system_prompt=SYSTEM_PROMPT,
+                mcp_servers={"users": user_mcp_server},
+                permission_mode="bypassPermissions",
                 max_turns=5,
             )
 
@@ -160,9 +231,7 @@ async def run_interactive() -> None:
                 ),
             ):
                 if isinstance(message, AssistantMessage):
-                    for block in message.content:
-                        if isinstance(block, TextBlock):
-                            print(block.text)
+                    _print_assistant_blocks(message)
                 elif isinstance(message, ResultMessage):
                     if (
                         hasattr(message, "total_cost_usd")
@@ -174,7 +243,7 @@ async def run_interactive() -> None:
             print()
 
         except KeyboardInterrupt:
-            print("\n\n👋 Goodbye!\n")
+            print("\n\n Goodbye!\n")
             break
         except Exception as e:
             print(f"\nError: {e}\n")

--- a/examples/claude-agent-sdk-python/requirements.txt
+++ b/examples/claude-agent-sdk-python/requirements.txt
@@ -1,0 +1,8 @@
+# TCC SDK with Claude Agent SDK support (local editable install)
+-e ../../packages/python[claude]
+
+# Claude Agent SDK
+claude-agent-sdk>=0.1.0
+
+# Environment variables
+python-dotenv>=1.0.1

--- a/packages/python/contextcompany/claude/__init__.py
+++ b/packages/python/contextcompany/claude/__init__.py
@@ -1,0 +1,26 @@
+"""Claude Agent SDK instrumentation for The Context Company.
+
+Wraps the Claude Agent SDK's query() function to transparently collect
+all messages and send them to the TCC backend for observability.
+
+Usage:
+    from contextcompany.claude import instrument_claude_agent, TCCConfig
+    from contextcompany import submit_feedback
+
+    agent = instrument_claude_agent()
+
+    async for message in agent.query(
+        prompt="Hello",
+        options=ClaudeAgentOptions(system_prompt="You are helpful."),
+        tcc_config=TCCConfig(run_id="my-run", session_id="my-session"),
+    ):
+        # Process messages normally — they are yielded transparently
+        ...
+
+    # Submit feedback on a run
+    submit_feedback(run_id="my-run", score="thumbs_up")
+"""
+
+from .claude import instrument_claude_agent, TCCConfig, InstrumentedClaudeAgent
+
+__all__ = ["instrument_claude_agent", "TCCConfig", "InstrumentedClaudeAgent"]

--- a/packages/python/contextcompany/claude/claude.py
+++ b/packages/python/contextcompany/claude/claude.py
@@ -446,16 +446,14 @@ class InstrumentedClaudeAgent:
                     )
 
                     yield message
-
+            finally:
+                # Covers normal completion, Exception, GeneratorExit (consumer
+                # break / aclose), and CancelledError. GeneratorExit is a
+                # BaseException so an `except Exception` clause would miss it,
+                # dropping every collected message.
                 if messages:
-                    _debug(f"Stream completed with {len(messages)} messages")
-                    _debug("Sending telemetry data...")
+                    _debug(f"Firing telemetry with {len(messages)} messages")
                     _fire_telemetry()
-
-            except Exception:
-                if messages:
-                    _fire_telemetry()
-                raise
         finally:
             _claude_debug.reset(debug_token)
 

--- a/packages/python/contextcompany/claude/claude.py
+++ b/packages/python/contextcompany/claude/claude.py
@@ -33,6 +33,7 @@ Usage::
                     print(block.text)
 """
 
+import asyncio
 import dataclasses
 import os
 import time
@@ -76,14 +77,7 @@ class TCCConfig:
 
 
 def _normalize_content_block(block: Any) -> Any:
-    """Convert an SDK ContentBlock dataclass back to the CLI wire shape.
-
-    The Python SDK's ``message_parser`` maps CLI JSON into typed dataclasses
-    that drop the ``type`` discriminator.  This inverts that mapping so the
-    telemetry payload matches what the TS wrapper (and the ``/v1/claude``
-    ingest parser) expect.  Type strings mirror
-    ``claude_agent_sdk/_internal/message_parser.py``.
-    """
+    """Serialise an SDK ContentBlock to the CLI wire shape with a ``type`` discriminator."""
     from claude_agent_sdk import (
         TextBlock,
         ThinkingBlock,
@@ -133,7 +127,6 @@ def _normalize_content_block(block: Any) -> Any:
             "content": block.content,
         }
 
-    # Unknown block shape — best effort so telemetry stays useful
     if dataclasses.is_dataclass(block) and not isinstance(block, type):
         try:
             return dataclasses.asdict(block)
@@ -143,14 +136,10 @@ def _normalize_content_block(block: Any) -> Any:
 
 
 def _message_to_dict(message: Any) -> Dict[str, Any]:
-    """Convert an SDK message dataclass to the CLI wire-format dict expected
-    by the TCC ``/v1/claude`` ingest parser.
+    """Serialise an SDK message to the CLI wire-format dict expected by ``/v1/claude``.
 
-    The Python SDK parses CLI JSON into typed dataclasses that drop both the
-    top-level ``type`` discriminator and (for assistant/user) the ``message``
-    wrapper.  The TS SDK passes the CLI JSON through unchanged, which is why
-    the TS wire format is the canonical ingest shape.  This function inverts
-    the Python parser so both languages produce identical payloads.
+    Inverts ``claude_agent_sdk/_internal/message_parser.py``: restores the
+    top-level ``type`` discriminator and (for assistant/user) the ``message`` wrapper.
     """
     from claude_agent_sdk import (
         AssistantMessage,
@@ -199,10 +188,8 @@ def _message_to_dict(message: Any) -> Dict[str, Any]:
         return out
 
     if isinstance(message, SystemMessage):
-        # SystemMessage.data is the full CLI dict — already contains
-        # ``type: "system"`` and ``subtype`` at top level plus every
-        # payload field (model, cwd, session_id, tools, ...).
-        # Shallow copy so downstream callers can mutate freely.
+        # ``data`` is the original CLI dict (already shaped for the wire);
+        # copy so later mutations don't leak into the SDK's message state.
         return dict(message.data)
 
     if isinstance(message, ResultMessage):
@@ -269,16 +256,11 @@ def _message_to_dict(message: Any) -> Dict[str, Any]:
             "session_id": message.session_id,
         }
 
-    # Unknown message type — fall back generically so telemetry keeps flowing
     if dataclasses.is_dataclass(message) and not isinstance(message, type):
         try:
             return dataclasses.asdict(message)
         except (TypeError, ValueError):
             pass
-    if hasattr(message, "__dict__"):
-        return {
-            k: v for k, v in message.__dict__.items() if not k.startswith("_")
-        }
     return {"raw": str(message)}
 
 
@@ -296,14 +278,7 @@ def _send_to_tcc(
     api_key: Optional[str],
     tcc_url: Optional[str],
 ) -> None:
-    """POST collected messages to the TCC ``/v1/claude`` endpoint.
-
-    The payload shape matches the TypeScript implementation so the same
-    backend handler can process both.
-    """
-    resolved_key = get_api_key(api_key)
-    endpoint = tcc_url or get_url("/v1/claude", api_key=resolved_key)
-
+    """POST collected messages to the TCC ``/v1/claude`` endpoint. Never raises."""
     payload: Dict[str, Any] = {
         "messages": messages,
         "runId": run_id,
@@ -319,6 +294,8 @@ def _send_to_tcc(
     _debug("Payload:", payload)
 
     try:
+        resolved_key = get_api_key(api_key)
+        endpoint = tcc_url or get_url("/v1/claude", api_key=resolved_key)
         resp = requests.post(
             endpoint,
             json=payload,
@@ -386,64 +363,53 @@ class InstrumentedClaudeAgent:
         session_id = config.session_id
         metadata = config.metadata or {}
 
-        # Honour the debug flag for this call
+        # Scope debug to this call so the flag doesn't leak into other
+        # concurrent or later queries (nor inherited child processes).
+        prev_debug = os.environ.get("TCC_DEBUG")
         if config.debug:
             os.environ["TCC_DEBUG"] = "true"
 
-        _debug("Claude query wrapper called")
-        _debug("runId:", run_id)
-        _debug("sessionId:", session_id)
-        _debug("metadata:", metadata)
-
-        messages: List[Dict[str, Any]] = []
-        user_prompt = prompt if isinstance(prompt, str) else None
-
         try:
-            _debug("Starting to collect messages")
+            _debug("Claude query wrapper called")
+            _debug("runId:", run_id)
+            _debug("sessionId:", session_id)
+            _debug("metadata:", metadata)
 
-            async for message in claude_query(
-                prompt=prompt,
-                options=options,
-                **({"transport": transport} if transport is not None else {}),
-            ):
-                # Serialise and timestamp the message
-                msg_dict = _message_to_dict(message)
-                msg_dict["receivedAtMs"] = int(time.time() * 1000)
-                msg_dict["tccMetadata"] = {
-                    "runId": run_id,
-                    "sessionId": session_id,
-                }
-                messages.append(msg_dict)
+            messages: List[Dict[str, Any]] = []
+            user_prompt = prompt if isinstance(prompt, str) else None
 
-                _debug(
-                    f"Collected message type: "
-                    f"{msg_dict.get('type', 'unknown')}, "
-                    f"total: {len(messages)}"
-                )
+            try:
+                _debug("Starting to collect messages")
 
-                # Yield transparently — downstream code sees the original
-                yield message
+                async for message in claude_query(
+                    prompt=prompt,
+                    options=options,
+                    **({"transport": transport} if transport is not None else {}),
+                ):
+                    msg_dict = _message_to_dict(message)
+                    msg_dict["receivedAtMs"] = int(time.time() * 1000)
+                    msg_dict["tccMetadata"] = {
+                        "runId": run_id,
+                        "sessionId": session_id,
+                    }
+                    messages.append(msg_dict)
 
-            # ----- Stream completed successfully ----- #
-            if messages:
-                _debug(f"Stream completed with {len(messages)} messages")
-                _debug("Sending telemetry data...")
+                    _debug(
+                        f"Collected message type: "
+                        f"{msg_dict.get('type', 'unknown')}, "
+                        f"total: {len(messages)}"
+                    )
 
-                _send_to_tcc(
-                    messages=messages,
-                    custom_metadata=metadata if metadata else None,
-                    run_id=run_id,
-                    session_id=session_id,
-                    user_prompt=user_prompt,
-                    api_key=self._api_key,
-                    tcc_url=self._tcc_url,
-                )
+                    yield message
 
-        except Exception:
-            # On error, attempt to send whatever we collected so far
-            if messages:
-                try:
-                    _send_to_tcc(
+                if messages:
+                    _debug(f"Stream completed with {len(messages)} messages")
+                    _debug("Sending telemetry data...")
+
+                    # Offload the blocking HTTP POST so it doesn't stall the
+                    # event loop (the caller is always an async coroutine).
+                    await asyncio.to_thread(
+                        _send_to_tcc,
                         messages=messages,
                         custom_metadata=metadata if metadata else None,
                         run_id=run_id,
@@ -452,9 +418,29 @@ class InstrumentedClaudeAgent:
                         api_key=self._api_key,
                         tcc_url=self._tcc_url,
                     )
-                except Exception:
-                    pass
-            raise
+
+            except Exception:
+                if messages:
+                    try:
+                        await asyncio.to_thread(
+                            _send_to_tcc,
+                            messages=messages,
+                            custom_metadata=metadata if metadata else None,
+                            run_id=run_id,
+                            session_id=session_id,
+                            user_prompt=user_prompt,
+                            api_key=self._api_key,
+                            tcc_url=self._tcc_url,
+                        )
+                    except Exception:
+                        pass
+                raise
+        finally:
+            if config.debug:
+                if prev_debug is None:
+                    os.environ.pop("TCC_DEBUG", None)
+                else:
+                    os.environ["TCC_DEBUG"] = prev_debug
 
 
 # ---------------------------------------------------------------------------

--- a/packages/python/contextcompany/claude/claude.py
+++ b/packages/python/contextcompany/claude/claude.py
@@ -34,7 +34,9 @@ Usage::
 """
 
 import asyncio
+import contextvars
 import dataclasses
+import json
 import os
 import time
 import uuid
@@ -43,8 +45,32 @@ from typing import Any, AsyncIterator, Dict, List, Optional
 
 import requests
 
-from .._utils import _debug
 from ..config import get_api_key, get_url
+
+
+# Per-call debug scope.  Using a ContextVar (not ``os.environ``) so concurrent
+# ``query()`` calls can't corrupt each other's debug state — ContextVars are
+# copy-on-write per asyncio Task, and ``asyncio.to_thread`` propagates them
+# into the worker thread, so ``_debug`` calls from ``_send_to_tcc`` also see
+# the caller's value.
+_claude_debug: contextvars.ContextVar[bool] = contextvars.ContextVar(
+    "tcc_claude_debug", default=False
+)
+
+
+def _debug(*args: Any) -> None:
+    if not _claude_debug.get() and os.getenv("TCC_DEBUG", "").lower() not in (
+        "true",
+        "1",
+    ):
+        return
+    parts = []
+    for arg in args:
+        if isinstance(arg, dict):
+            parts.append(json.dumps(arg, indent=2))
+        else:
+            parts.append(str(arg))
+    print("[TCC Debug]", *parts)
 
 
 # ---------------------------------------------------------------------------
@@ -363,11 +389,7 @@ class InstrumentedClaudeAgent:
         session_id = config.session_id
         metadata = config.metadata or {}
 
-        # Scope debug to this call so the flag doesn't leak into other
-        # concurrent or later queries (nor inherited child processes).
-        prev_debug = os.environ.get("TCC_DEBUG")
-        if config.debug:
-            os.environ["TCC_DEBUG"] = "true"
+        debug_token = _claude_debug.set(config.debug)
 
         try:
             _debug("Claude query wrapper called")
@@ -436,11 +458,7 @@ class InstrumentedClaudeAgent:
                         pass
                 raise
         finally:
-            if config.debug:
-                if prev_debug is None:
-                    os.environ.pop("TCC_DEBUG", None)
-                else:
-                    os.environ["TCC_DEBUG"] = prev_debug
+            _claude_debug.reset(debug_token)
 
 
 # ---------------------------------------------------------------------------

--- a/packages/python/contextcompany/claude/claude.py
+++ b/packages/python/contextcompany/claude/claude.py
@@ -1,0 +1,302 @@
+"""Claude Agent SDK instrumentation for The Context Company.
+
+Wraps the Claude Agent SDK's ``query()`` function to transparently collect
+all streamed messages and send them to the TCC backend for observability.
+
+The approach mirrors the TypeScript implementation in
+``packages/ts/claude/src/claude.ts``:
+
+1.  ``instrument_claude_agent()`` returns an :class:`InstrumentedClaudeAgent`
+    whose ``query()`` method wraps ``claude_agent_sdk.query()``.
+2.  Every message yielded by the underlying async iterator is serialised to a
+    dict, timestamped with ``receivedAtMs``, and collected.
+3.  The original message objects are yielded transparently so downstream code
+    is unaffected.
+4.  After the stream completes (or on error) the collected messages are
+    POSTed to the ``/v1/claude`` endpoint.
+
+Usage::
+
+    from contextcompany.claude import instrument_claude_agent, TCCConfig
+    from claude_agent_sdk import ClaudeAgentOptions, AssistantMessage, TextBlock
+
+    agent = instrument_claude_agent()
+
+    async for message in agent.query(
+        prompt="What is 2 + 2?",
+        options=ClaudeAgentOptions(system_prompt="You are helpful."),
+        tcc_config=TCCConfig(run_id="my-run", session_id="my-session"),
+    ):
+        if isinstance(message, AssistantMessage):
+            for block in message.content:
+                if isinstance(block, TextBlock):
+                    print(block.text)
+"""
+
+import dataclasses
+import os
+import time
+import uuid
+from dataclasses import dataclass
+from typing import Any, AsyncIterator, Dict, List, Optional
+
+import requests
+
+from .._utils import _debug
+from ..config import get_api_key, get_url
+
+
+# ---------------------------------------------------------------------------
+# Public dataclass – users pass this to ``query()``
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class TCCConfig:
+    """TCC configuration for a single ``query()`` call.
+
+    Attributes:
+        run_id:     Unique identifier for the run.  Auto-generated if not set.
+        session_id: Optional session identifier to group related runs.
+        metadata:   Arbitrary key/value metadata attached to the telemetry
+                    payload (sent as ``customMetadata``).
+        debug:      If ``True``, enables verbose ``[TCC Debug]`` logging for
+                    this call (also honours the ``TCC_DEBUG`` env-var).
+    """
+
+    run_id: Optional[str] = None
+    session_id: Optional[str] = None
+    metadata: Optional[Dict[str, Any]] = None
+    debug: bool = False
+
+
+# ---------------------------------------------------------------------------
+# Message serialisation helper
+# ---------------------------------------------------------------------------
+
+
+def _message_to_dict(message: Any) -> Dict[str, Any]:
+    """Convert a Claude SDK message to a JSON-serialisable dict.
+
+    The SDK message types are dataclasses, so ``dataclasses.asdict()`` is the
+    primary strategy.  Falls back to ``__dict__`` scraping and finally
+    ``str()`` for totally opaque objects.
+    """
+    if dataclasses.is_dataclass(message) and not isinstance(message, type):
+        try:
+            return dataclasses.asdict(message)
+        except (TypeError, ValueError):
+            # Some nested objects may not be serialisable via asdict
+            pass
+
+    if hasattr(message, "__dict__"):
+        return {
+            k: v for k, v in message.__dict__.items() if not k.startswith("_")
+        }
+
+    return {"raw": str(message)}
+
+
+# ---------------------------------------------------------------------------
+# Telemetry sender
+# ---------------------------------------------------------------------------
+
+
+def _send_to_tcc(
+    messages: List[Dict[str, Any]],
+    custom_metadata: Optional[Dict[str, Any]],
+    run_id: str,
+    session_id: Optional[str],
+    user_prompt: Optional[str],
+    api_key: Optional[str],
+    tcc_url: Optional[str],
+) -> None:
+    """POST collected messages to the TCC ``/v1/claude`` endpoint.
+
+    The payload shape matches the TypeScript implementation so the same
+    backend handler can process both.
+    """
+    resolved_key = get_api_key(api_key)
+    endpoint = tcc_url or get_url("/v1/claude", api_key=resolved_key)
+
+    payload: Dict[str, Any] = {
+        "messages": messages,
+        "runId": run_id,
+    }
+    if custom_metadata:
+        payload["customMetadata"] = custom_metadata
+    if session_id is not None:
+        payload["sessionId"] = session_id
+    if user_prompt is not None:
+        payload["userPrompt"] = user_prompt
+
+    _debug("Sending claude telemetry...")
+    _debug("Payload:", payload)
+
+    try:
+        resp = requests.post(
+            endpoint,
+            json=payload,
+            headers={
+                "Content-Type": "application/json",
+                "Authorization": f"Bearer {resolved_key}",
+            },
+            timeout=10,
+        )
+
+        if not resp.ok:
+            print(
+                f"[TCC] Failed to send claude telemetry: "
+                f"{resp.status_code} {resp.text}"
+            )
+        else:
+            _debug(f"Successfully sent {len(messages)} claude messages")
+    except Exception as e:
+        print(f"[TCC] Error sending claude telemetry: {e}")
+
+
+# ---------------------------------------------------------------------------
+# Instrumented wrapper
+# ---------------------------------------------------------------------------
+
+
+class InstrumentedClaudeAgent:
+    """Wrapped Claude Agent SDK with TCC telemetry collection.
+
+    Instantiate via :func:`instrument_claude_agent` rather than directly.
+    """
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        tcc_url: Optional[str] = None,
+    ) -> None:
+        self._api_key = api_key
+        self._tcc_url = tcc_url
+
+    # The return-type annotation is kept generic (``AsyncIterator``) to avoid
+    # importing ``claude_agent_sdk`` at module level — the SDK is an optional
+    # dependency.
+    async def query(
+        self,
+        *,
+        prompt: Any,
+        options: Any = None,
+        transport: Any = None,
+        tcc_config: Optional[TCCConfig] = None,
+    ) -> AsyncIterator:
+        """Wrap ``claude_agent_sdk.query()`` with TCC telemetry.
+
+        Parameters are identical to the upstream ``query()`` function with the
+        addition of *tcc_config* for TCC-specific settings.
+
+        Yields:
+            The same ``Message`` objects that the upstream SDK yields.
+        """
+        from claude_agent_sdk import query as claude_query
+
+        config = tcc_config or TCCConfig()
+
+        run_id = config.run_id or str(uuid.uuid4())
+        session_id = config.session_id
+        metadata = config.metadata or {}
+
+        # Honour the debug flag for this call
+        if config.debug:
+            os.environ["TCC_DEBUG"] = "true"
+
+        _debug("Claude query wrapper called")
+        _debug("runId:", run_id)
+        _debug("sessionId:", session_id)
+        _debug("metadata:", metadata)
+
+        messages: List[Dict[str, Any]] = []
+        user_prompt = prompt if isinstance(prompt, str) else None
+
+        try:
+            _debug("Starting to collect messages")
+
+            async for message in claude_query(
+                prompt=prompt,
+                options=options,
+                **({"transport": transport} if transport is not None else {}),
+            ):
+                # Serialise and timestamp the message
+                msg_dict = _message_to_dict(message)
+                msg_dict["receivedAtMs"] = int(time.time() * 1000)
+                msg_dict["tccMetadata"] = {
+                    "runId": run_id,
+                    "sessionId": session_id,
+                }
+                messages.append(msg_dict)
+
+                _debug(
+                    f"Collected message type: "
+                    f"{msg_dict.get('type', 'unknown')}, "
+                    f"total: {len(messages)}"
+                )
+
+                # Yield transparently — downstream code sees the original
+                yield message
+
+            # ----- Stream completed successfully ----- #
+            if messages:
+                _debug(f"Stream completed with {len(messages)} messages")
+                _debug("Sending telemetry data...")
+
+                _send_to_tcc(
+                    messages=messages,
+                    custom_metadata=metadata if metadata else None,
+                    run_id=run_id,
+                    session_id=session_id,
+                    user_prompt=user_prompt,
+                    api_key=self._api_key,
+                    tcc_url=self._tcc_url,
+                )
+
+        except Exception:
+            # On error, attempt to send whatever we collected so far
+            if messages:
+                try:
+                    _send_to_tcc(
+                        messages=messages,
+                        custom_metadata=metadata if metadata else None,
+                        run_id=run_id,
+                        session_id=session_id,
+                        user_prompt=user_prompt,
+                        api_key=self._api_key,
+                        tcc_url=self._tcc_url,
+                    )
+                except Exception:
+                    pass
+            raise
+
+
+# ---------------------------------------------------------------------------
+# Public factory
+# ---------------------------------------------------------------------------
+
+
+def instrument_claude_agent(
+    api_key: Optional[str] = None,
+    tcc_url: Optional[str] = None,
+) -> InstrumentedClaudeAgent:
+    """Instrument the Claude Agent SDK for automatic observability.
+
+    Returns an :class:`InstrumentedClaudeAgent` whose ``query()`` async
+    generator wraps ``claude_agent_sdk.query()`` with TCC telemetry
+    collection.
+
+    Call once at startup, then use the returned object's ``query()`` method
+    in place of the SDK's ``query()``.
+
+    Args:
+        api_key: TCC API key.  Falls back to the ``TCC_API_KEY`` env-var.
+        tcc_url: Override the TCC endpoint URL.  Falls back to automatic
+                 prod/dev selection based on the key prefix.
+
+    Returns:
+        An :class:`InstrumentedClaudeAgent` instance.
+    """
+    _debug("Initializing Claude Agent SDK instrumentation")
+    return InstrumentedClaudeAgent(api_key=api_key, tcc_url=tcc_url)

--- a/packages/python/contextcompany/claude/claude.py
+++ b/packages/python/contextcompany/claude/claude.py
@@ -348,6 +348,12 @@ def _send_to_tcc(
 # ---------------------------------------------------------------------------
 
 
+# asyncio only holds weak references to Tasks — fire-and-forget telemetry
+# would be GC'd mid-flight without a strong ref.  Tasks add themselves here
+# and remove themselves via a done callback.
+_pending_telemetry_tasks: set = set()
+
+
 class InstrumentedClaudeAgent:
     """Wrapped Claude Agent SDK with TCC telemetry collection.
 
@@ -400,6 +406,23 @@ class InstrumentedClaudeAgent:
             messages: List[Dict[str, Any]] = []
             user_prompt = prompt if isinstance(prompt, str) else None
 
+            def _fire_telemetry() -> None:
+                """Schedule a fire-and-forget telemetry POST (mirrors TS)."""
+                task = asyncio.create_task(
+                    asyncio.to_thread(
+                        _send_to_tcc,
+                        messages=messages,
+                        custom_metadata=metadata if metadata else None,
+                        run_id=run_id,
+                        session_id=session_id,
+                        user_prompt=user_prompt,
+                        api_key=self._api_key,
+                        tcc_url=self._tcc_url,
+                    )
+                )
+                _pending_telemetry_tasks.add(task)
+                task.add_done_callback(_pending_telemetry_tasks.discard)
+
             try:
                 _debug("Starting to collect messages")
 
@@ -427,35 +450,11 @@ class InstrumentedClaudeAgent:
                 if messages:
                     _debug(f"Stream completed with {len(messages)} messages")
                     _debug("Sending telemetry data...")
-
-                    # Offload the blocking HTTP POST so it doesn't stall the
-                    # event loop (the caller is always an async coroutine).
-                    await asyncio.to_thread(
-                        _send_to_tcc,
-                        messages=messages,
-                        custom_metadata=metadata if metadata else None,
-                        run_id=run_id,
-                        session_id=session_id,
-                        user_prompt=user_prompt,
-                        api_key=self._api_key,
-                        tcc_url=self._tcc_url,
-                    )
+                    _fire_telemetry()
 
             except Exception:
                 if messages:
-                    try:
-                        await asyncio.to_thread(
-                            _send_to_tcc,
-                            messages=messages,
-                            custom_metadata=metadata if metadata else None,
-                            run_id=run_id,
-                            session_id=session_id,
-                            user_prompt=user_prompt,
-                            api_key=self._api_key,
-                            tcc_url=self._tcc_url,
-                        )
-                    except Exception:
-                        pass
+                    _fire_telemetry()
                 raise
         finally:
             _claude_debug.reset(debug_token)

--- a/packages/python/contextcompany/claude/claude.py
+++ b/packages/python/contextcompany/claude/claude.py
@@ -75,25 +75,210 @@ class TCCConfig:
 # ---------------------------------------------------------------------------
 
 
-def _message_to_dict(message: Any) -> Dict[str, Any]:
-    """Convert a Claude SDK message to a JSON-serialisable dict.
+def _normalize_content_block(block: Any) -> Any:
+    """Convert an SDK ContentBlock dataclass back to the CLI wire shape.
 
-    The SDK message types are dataclasses, so ``dataclasses.asdict()`` is the
-    primary strategy.  Falls back to ``__dict__`` scraping and finally
-    ``str()`` for totally opaque objects.
+    The Python SDK's ``message_parser`` maps CLI JSON into typed dataclasses
+    that drop the ``type`` discriminator.  This inverts that mapping so the
+    telemetry payload matches what the TS wrapper (and the ``/v1/claude``
+    ingest parser) expect.  Type strings mirror
+    ``claude_agent_sdk/_internal/message_parser.py``.
     """
+    from claude_agent_sdk import (
+        TextBlock,
+        ThinkingBlock,
+        ToolUseBlock,
+        ToolResultBlock,
+        ServerToolUseBlock,
+        ServerToolResultBlock,
+    )
+
+    if isinstance(block, TextBlock):
+        return {"type": "text", "text": block.text}
+    if isinstance(block, ThinkingBlock):
+        return {
+            "type": "thinking",
+            "thinking": block.thinking,
+            "signature": block.signature,
+        }
+    if isinstance(block, ToolUseBlock):
+        return {
+            "type": "tool_use",
+            "id": block.id,
+            "name": block.name,
+            "input": block.input,
+        }
+    if isinstance(block, ToolResultBlock):
+        out: Dict[str, Any] = {
+            "type": "tool_result",
+            "tool_use_id": block.tool_use_id,
+        }
+        if block.content is not None:
+            out["content"] = block.content
+        if block.is_error is not None:
+            out["is_error"] = block.is_error
+        return out
+    if isinstance(block, ServerToolUseBlock):
+        return {
+            "type": "server_tool_use",
+            "id": block.id,
+            "name": block.name,
+            "input": block.input,
+        }
+    if isinstance(block, ServerToolResultBlock):
+        # Parser discriminator for this class is "advisor_tool_result"
+        return {
+            "type": "advisor_tool_result",
+            "tool_use_id": block.tool_use_id,
+            "content": block.content,
+        }
+
+    # Unknown block shape — best effort so telemetry stays useful
+    if dataclasses.is_dataclass(block) and not isinstance(block, type):
+        try:
+            return dataclasses.asdict(block)
+        except (TypeError, ValueError):
+            pass
+    return {"raw": str(block)}
+
+
+def _message_to_dict(message: Any) -> Dict[str, Any]:
+    """Convert an SDK message dataclass to the CLI wire-format dict expected
+    by the TCC ``/v1/claude`` ingest parser.
+
+    The Python SDK parses CLI JSON into typed dataclasses that drop both the
+    top-level ``type`` discriminator and (for assistant/user) the ``message``
+    wrapper.  The TS SDK passes the CLI JSON through unchanged, which is why
+    the TS wire format is the canonical ingest shape.  This function inverts
+    the Python parser so both languages produce identical payloads.
+    """
+    from claude_agent_sdk import (
+        AssistantMessage,
+        RateLimitEvent,
+        ResultMessage,
+        StreamEvent,
+        SystemMessage,
+        UserMessage,
+    )
+
+    if isinstance(message, AssistantMessage):
+        inner: Dict[str, Any] = {
+            "content": [_normalize_content_block(b) for b in message.content],
+            "model": message.model,
+        }
+        if message.message_id is not None:
+            inner["id"] = message.message_id
+        if message.usage is not None:
+            inner["usage"] = message.usage
+        if message.stop_reason is not None:
+            inner["stop_reason"] = message.stop_reason
+
+        out: Dict[str, Any] = {"type": "assistant", "message": inner}
+        if message.parent_tool_use_id is not None:
+            out["parent_tool_use_id"] = message.parent_tool_use_id
+        if message.error is not None:
+            out["error"] = message.error
+        if message.session_id is not None:
+            out["session_id"] = message.session_id
+        if message.uuid is not None:
+            out["uuid"] = message.uuid
+        return out
+
+    if isinstance(message, UserMessage):
+        if isinstance(message.content, list):
+            content: Any = [_normalize_content_block(b) for b in message.content]
+        else:
+            content = message.content
+        out = {"type": "user", "message": {"content": content}}
+        if message.parent_tool_use_id is not None:
+            out["parent_tool_use_id"] = message.parent_tool_use_id
+        if message.tool_use_result is not None:
+            out["tool_use_result"] = message.tool_use_result
+        if message.uuid is not None:
+            out["uuid"] = message.uuid
+        return out
+
+    if isinstance(message, SystemMessage):
+        # SystemMessage.data is the full CLI dict — already contains
+        # ``type: "system"`` and ``subtype`` at top level plus every
+        # payload field (model, cwd, session_id, tools, ...).
+        # Shallow copy so downstream callers can mutate freely.
+        return dict(message.data)
+
+    if isinstance(message, ResultMessage):
+        out = {
+            "type": "result",
+            "subtype": message.subtype,
+            "duration_ms": message.duration_ms,
+            "duration_api_ms": message.duration_api_ms,
+            "is_error": message.is_error,
+            "num_turns": message.num_turns,
+            "session_id": message.session_id,
+        }
+        if message.stop_reason is not None:
+            out["stop_reason"] = message.stop_reason
+        if message.total_cost_usd is not None:
+            out["total_cost_usd"] = message.total_cost_usd
+        if message.usage is not None:
+            out["usage"] = message.usage
+        if message.result is not None:
+            out["result"] = message.result
+        if message.structured_output is not None:
+            out["structured_output"] = message.structured_output
+        # Wire key is camelCase "modelUsage"; Python renames to snake on parse.
+        if message.model_usage is not None:
+            out["modelUsage"] = message.model_usage
+        if message.permission_denials is not None:
+            out["permission_denials"] = message.permission_denials
+        if message.errors is not None:
+            out["errors"] = message.errors
+        if message.uuid is not None:
+            out["uuid"] = message.uuid
+        return out
+
+    if isinstance(message, StreamEvent):
+        out = {
+            "type": "stream_event",
+            "uuid": message.uuid,
+            "session_id": message.session_id,
+            "event": message.event,
+        }
+        if message.parent_tool_use_id is not None:
+            out["parent_tool_use_id"] = message.parent_tool_use_id
+        return out
+
+    if isinstance(message, RateLimitEvent):
+        info = message.rate_limit_info
+        info_dict: Dict[str, Any] = {"status": info.status}
+        if info.resets_at is not None:
+            info_dict["resetsAt"] = info.resets_at
+        if info.rate_limit_type is not None:
+            info_dict["rateLimitType"] = info.rate_limit_type
+        if info.utilization is not None:
+            info_dict["utilization"] = info.utilization
+        if info.overage_status is not None:
+            info_dict["overageStatus"] = info.overage_status
+        if info.overage_resets_at is not None:
+            info_dict["overageResetsAt"] = info.overage_resets_at
+        if info.overage_disabled_reason is not None:
+            info_dict["overageDisabledReason"] = info.overage_disabled_reason
+        return {
+            "type": "rate_limit_event",
+            "rate_limit_info": info_dict,
+            "uuid": message.uuid,
+            "session_id": message.session_id,
+        }
+
+    # Unknown message type — fall back generically so telemetry keeps flowing
     if dataclasses.is_dataclass(message) and not isinstance(message, type):
         try:
             return dataclasses.asdict(message)
         except (TypeError, ValueError):
-            # Some nested objects may not be serialisable via asdict
             pass
-
     if hasattr(message, "__dict__"):
         return {
             k: v for k, v in message.__dict__.items() if not k.startswith("_")
         }
-
     return {"raw": str(message)}
 
 

--- a/packages/python/pyproject.toml
+++ b/packages/python/pyproject.toml
@@ -52,6 +52,9 @@ crewai = [
     "crewai>=0.70.0",
     "wrapt>=1.14.0",
 ]
+claude = [
+    "claude-agent-sdk>=0.1.0",
+]
 
 [project.urls]
 Homepage = "https://thecontext.company"


### PR DESCRIPTION
## 🎯 Changes

What changes are made in this PR? Is it a feature or a bug fix?

## ✅ Checklist

- [ ] I have followed the steps listed in the Contributing guide.
- [ ] If necessary, I have added documentation related to the changes made.
- [ ] If applicable, I have added or updated the tests related to the changes made.

## 🔒 Related Issues

Closes #

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new async instrumentation that serializes and POSTs all Claude Agent SDK messages to TCC in a background task, which could impact telemetry correctness/performance and network error handling. Changes are mostly additive but touch observability data capture and outbound HTTP behavior.
> 
> **Overview**
> Adds a new `contextcompany.claude` module that wraps the Claude Agent SDK `query()` stream to **collect/serialize all streamed messages**, attach run/session metadata, and **fire-and-forget POST** the telemetry to TCC’s `/v1/claude` endpoint.
> 
> Updates Python packaging to expose a new optional extra `claude`, and adds a complete `examples/claude-agent-sdk-python` project (env/requirements/README + interactive `main.py`) demonstrating MCP tool usage, session/run tracking, and `submit_feedback()` integration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35e856d2d8feac30ff08d801ea193126a62705e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->