### PR TITLE
feat(openclaw): Share per-turn run IDs across multiple plugin instances in the same process

### DIFF
--- a/.changeset/openclaw-coordinate-runid-across-instances.md
+++ b/.changeset/openclaw-coordinate-runid-across-instances.md
@@ -1,0 +1,7 @@
+---
+"@contextcompany/openclaw": patch
+---
+
+Share per-turn run IDs across multiple plugin instances in the same process.
+
+Registering the plugin more than once in a single process (e.g. via `openclaw.json` plus a custom extension calling `register()`) caused each instance to mint its own runId for the same turn, producing duplicate rows on the server. Instances now converge on a shared runId per `sessionKey`, released on `agent_end` with a 30-minute TTL.

--- a/packages/ts/openclaw/src/plugin.ts
+++ b/packages/ts/openclaw/src/plugin.ts
@@ -46,8 +46,11 @@ function acquireTurnRunId(sessionKey: string): string {
   return runId;
 }
 
-function releaseTurnRunId(sessionKey: string): void {
-  turnRunIdCache.delete(sessionKey);
+function releaseTurnRunId(sessionKey: string, runId: string): void {
+  const existing = turnRunIdCache.get(sessionKey);
+  if (existing && existing.runId === runId) {
+    turnRunIdCache.delete(sessionKey);
+  }
 }
 
 function resolveDefaultSessionId(
@@ -173,7 +176,7 @@ function registerHooks(
         });
 
         activeSessions.delete(key);
-        releaseTurnRunId(key);
+        releaseTurnRunId(key, session.runId);
       }
     }
   }, 5 * 60 * 1000);
@@ -354,7 +357,7 @@ function registerHooks(
       // awaiting onRunEnd, ensureSession must create a fresh session
       // rather than appending to this already-flushed one.
       activeSessions.delete(sessionKey);
-      releaseTurnRunId(sessionKey);
+      releaseTurnRunId(sessionKey, session.runId);
 
       if (debug)
         log.info(

--- a/packages/ts/openclaw/src/plugin.ts
+++ b/packages/ts/openclaw/src/plugin.ts
@@ -30,6 +30,26 @@ export type {
 } from "./types.js";
 import { safeClone, sendToTcc } from "./transport.js";
 
+// Module-level so multiple registrations in the same process converge on
+// one runId per turn, instead of each minting its own.
+const turnRunIdCache = new Map<string, { runId: string; createdAt: number }>();
+const TURN_RUN_ID_MAX_AGE_MS = 30 * 60 * 1000;
+
+function acquireTurnRunId(sessionKey: string): string {
+  const now = Date.now();
+  const existing = turnRunIdCache.get(sessionKey);
+  if (existing && now - existing.createdAt < TURN_RUN_ID_MAX_AGE_MS) {
+    return existing.runId;
+  }
+  const runId = crypto.randomUUID();
+  turnRunIdCache.set(sessionKey, { runId, createdAt: now });
+  return runId;
+}
+
+function releaseTurnRunId(sessionKey: string): void {
+  turnRunIdCache.delete(sessionKey);
+}
+
 function resolveDefaultSessionId(
   def: OpenClawDefaultSessionId | undefined,
   ctx: OpenClawRunContext,
@@ -153,6 +173,7 @@ function registerHooks(
         });
 
         activeSessions.delete(key);
+        releaseTurnRunId(key);
       }
     }
   }, 5 * 60 * 1000);
@@ -191,14 +212,13 @@ function registerHooks(
     let session = activeSessions.get(sessionKey);
     if (session) return session;
 
-    // Mint a fresh runId per turn. Legacy top-level runId (if present) wins
-    // ONLY the first time — same as before, preserved for backwards compat.
+    // Legacy top-level runId wins once; otherwise share via turnRunIdCache.
     let runId: string;
     if (legacyNextRunId) {
       runId = legacyNextRunId;
       legacyNextRunId = null;
     } else {
-      runId = crypto.randomUUID();
+      runId = acquireTurnRunId(sessionKey);
     }
 
     // sessionId resolution order:
@@ -334,6 +354,7 @@ function registerHooks(
       // awaiting onRunEnd, ensureSession must create a fresh session
       // rather than appending to this already-flushed one.
       activeSessions.delete(sessionKey);
+      releaseTurnRunId(sessionKey);
 
       if (debug)
         log.info(

--- a/packages/ts/openclaw/src/plugin.ts
+++ b/packages/ts/openclaw/src/plugin.ts
@@ -176,7 +176,9 @@ function registerHooks(
         });
 
         activeSessions.delete(key);
-        releaseTurnRunId(key, session.runId);
+        if (session.turnCacheRunId) {
+          releaseTurnRunId(key, session.turnCacheRunId);
+        }
       }
     }
   }, 5 * 60 * 1000);
@@ -217,11 +219,13 @@ function registerHooks(
 
     // Legacy top-level runId wins once; otherwise share via turnRunIdCache.
     let runId: string;
+    let turnCacheRunId: string | undefined;
     if (legacyNextRunId) {
       runId = legacyNextRunId;
       legacyNextRunId = null;
     } else {
       runId = acquireTurnRunId(sessionKey);
+      turnCacheRunId = runId;
     }
 
     // sessionId resolution order:
@@ -239,6 +243,7 @@ function registerHooks(
       runId,
       sessionId: defaultSessionId ?? ctx.sessionKey,
       metadata: defaultMetadata,
+      turnCacheRunId,
     };
     activeSessions.set(sessionKey, session);
 
@@ -357,7 +362,9 @@ function registerHooks(
       // awaiting onRunEnd, ensureSession must create a fresh session
       // rather than appending to this already-flushed one.
       activeSessions.delete(sessionKey);
-      releaseTurnRunId(sessionKey, session.runId);
+      if (session.turnCacheRunId) {
+        releaseTurnRunId(sessionKey, session.turnCacheRunId);
+      }
 
       if (debug)
         log.info(

--- a/packages/ts/openclaw/src/types.ts
+++ b/packages/ts/openclaw/src/types.ts
@@ -23,6 +23,7 @@ export type ActiveSession = {
   runId: string;
   sessionId?: string;
   metadata: Record<string, string>;
+  turnCacheRunId?: string;
 };
 
 /** Mutation API passed into onRunStart. Changes apply to this run only. */


### PR DESCRIPTION
…es in the same process

## 🎯 Changes

What changes are made in this PR? Is it a feature or a bug fix?

## ✅ Checklist

- [ ] I have followed the steps listed in the Contributing guide.
- [ ] If necessary, I have added documentation related to the changes made.
- [ ] If applicable, I have added or updated the tests related to the changes made.

## 🔒 Related Issues

Closes #

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes `runId` lifecycle and introduces a module-level cache/TTL; bugs could cause run correlation issues or leaked cache entries across turns.
> 
> **Overview**
> Prevents duplicate server rows when `@contextcompany/openclaw` is registered multiple times in the same process by **sharing a single per-turn `runId` per `sessionKey`**.
> 
> Adds a module-level `turnRunIdCache` with a 30-minute TTL, uses it when minting new sessions, and releases cached IDs on `agent_end` and stale-session cleanup; `ActiveSession` now tracks `turnCacheRunId` to safely release only cache-owned IDs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69d7e2901def55b11f1019e510195f203528c8c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->