### PR TITLE
feat(python): Change Claude Agent SDK to include `conversational` flag

### DIFF
--- a/.changeset/claude-conversational-flag.md
+++ b/.changeset/claude-conversational-flag.md
@@ -1,0 +1,7 @@
+---
+"@contextcompany/claude": minor
+---
+
+Add `conversational` flag to `TCCConfig` to mark a run as user-initiated.
+
+When set, the value is forwarded as the reserved `tcc.conversational` metadata key on the wire, matching the contract used by other TCC integrations. Existing callers are unaffected; the field is optional.

--- a/packages/python/contextcompany/claude/claude.py
+++ b/packages/python/contextcompany/claude/claude.py
@@ -397,8 +397,6 @@ class InstrumentedClaudeAgent:
 
         run_id = config.run_id or str(uuid.uuid4())
         session_id = config.session_id
-        # Forward user metadata, and stamp the typed `conversational` flag as
-        # `tcc.conversational` so the ingest contract sees a single source of truth.
         metadata = dict(config.metadata) if config.metadata else {}
         if config.conversational is not None:
             metadata["tcc.conversational"] = config.conversational

--- a/packages/python/contextcompany/claude/claude.py
+++ b/packages/python/contextcompany/claude/claude.py
@@ -83,16 +83,20 @@ class TCCConfig:
     """TCC configuration for a single ``query()`` call.
 
     Attributes:
-        run_id:     Unique identifier for the run.  Auto-generated if not set.
-        session_id: Optional session identifier to group related runs.
-        metadata:   Arbitrary key/value metadata attached to the telemetry
-                    payload (sent as ``customMetadata``).
-        debug:      If ``True``, enables verbose ``[TCC Debug]`` logging for
-                    this call (also honours the ``TCC_DEBUG`` env-var).
+        run_id:        Unique identifier for the run.  Auto-generated if not set.
+        session_id:    Optional session identifier to group related runs.
+        conversational: Mark this run as user-initiated (so it's analyzed for
+                       user insights). Forwarded as the reserved
+                       ``tcc.conversational`` metadata key on the wire.
+        metadata:      Arbitrary key/value metadata attached to the telemetry
+                       payload (sent as ``customMetadata``).
+        debug:         If ``True``, enables verbose ``[TCC Debug]`` logging for
+                       this call (also honours the ``TCC_DEBUG`` env-var).
     """
 
     run_id: Optional[str] = None
     session_id: Optional[str] = None
+    conversational: Optional[bool] = None
     metadata: Optional[Dict[str, Any]] = None
     debug: bool = False
 
@@ -393,7 +397,11 @@ class InstrumentedClaudeAgent:
 
         run_id = config.run_id or str(uuid.uuid4())
         session_id = config.session_id
-        metadata = config.metadata or {}
+        # Forward user metadata, and stamp the typed `conversational` flag as
+        # `tcc.conversational` so the ingest contract sees a single source of truth.
+        metadata = dict(config.metadata) if config.metadata else {}
+        if config.conversational is not None:
+            metadata["tcc.conversational"] = config.conversational
 
         debug_token = _claude_debug.set(config.debug)
 

--- a/packages/ts/claude/src/claude.ts
+++ b/packages/ts/claude/src/claude.ts
@@ -17,6 +17,8 @@ let DEBUG_ENABLED = false;
 export type TCCConfig = {
   runId?: string;
   sessionId?: string;
+  /** Mark this run as user-initiated (so it's analyzed for user insights). */
+  conversational?: boolean;
   metadata?: Record<string, unknown>;
   debug?: boolean;
 };
@@ -62,8 +64,13 @@ function instrumentQuery(queryFn: QueryFn, target: unknown): QueryFn {
         (tccConfig?.metadata?.["tcc.sessionId"] as string | undefined) ??
         null;
 
-      // Build final metadata: user metadata only (no tcc.* fields)
-      const metadata: Record<string, unknown> = tccConfig?.metadata || {};
+      // Build final metadata: forward user metadata, and stamp the typed
+      // `conversational` flag as `tcc.conversational` so the ingest contract
+      // sees a single source of truth.
+      const metadata: Record<string, unknown> = { ...(tccConfig?.metadata || {}) };
+      if (tccConfig?.conversational !== undefined) {
+        metadata["tcc.conversational"] = tccConfig.conversational;
+      }
 
       if (DEBUG_ENABLED) {
         console.log("[TCC Debug] Query wrapper called");

--- a/packages/ts/claude/src/claude.ts
+++ b/packages/ts/claude/src/claude.ts
@@ -64,9 +64,6 @@ function instrumentQuery(queryFn: QueryFn, target: unknown): QueryFn {
         (tccConfig?.metadata?.["tcc.sessionId"] as string | undefined) ??
         null;
 
-      // Build final metadata: forward user metadata, and stamp the typed
-      // `conversational` flag as `tcc.conversational` so the ingest contract
-      // sees a single source of truth.
       const metadata: Record<string, unknown> = { ...(tccConfig?.metadata || {}) };
       if (tccConfig?.conversational !== undefined) {
         metadata["tcc.conversational"] = tccConfig.conversational;


### PR DESCRIPTION
## 🎯 Changes

What changes are made in this PR? Is it a feature or a bug fix?

## ✅ Checklist

- [ ] I have followed the steps listed in the Contributing guide.
- [ ] If necessary, I have added documentation related to the changes made.
- [ ] If applicable, I have added or updated the tests related to the changes made.

## 🔒 Related Issues

Closes #

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds an optional config field and forwards it as metadata without changing default behavior. Main risk is minor metadata-shape changes if callers relied on mutating or sharing the original metadata object.
> 
> **Overview**
> Adds an optional `conversational` flag to `TCCConfig` (Python + TypeScript) to mark runs as user-initiated.
> 
> When set, the wrappers copy/extend the provided metadata and forward the value on the wire as the reserved `tcc.conversational` key, and a changeset bumps `@contextcompany/claude` as a minor release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ddafd960a70251c5f7a20e2bee06df8dd1dd475. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->