### PR TITLE
Add Python LangChain local OTLP mode

### DIFF
--- a/.changeset/python-langchain-local-otlp.md
+++ b/.changeset/python-langchain-local-otlp.md
@@ -1,0 +1,4 @@
+---
+---
+
+Add Python LangChain local OTLP mode.

--- a/packages/python/README.md
+++ b/packages/python/README.md
@@ -3,3 +3,18 @@
 The Context Company AI Agent Observability SDK for Python.
 
 For setup instructions, see our [documentation](https://docs.thecontext.company).
+
+## LangChain local mode
+
+For local LangChain/LangGraph development, you can export traces to a local OTLP
+HTTP collector without setting a TCC API key:
+
+```python
+from contextcompany.langchain import instrument_langchain
+
+instrument_langchain(local=True)
+```
+
+By default, local mode sends traces to `http://localhost:4318/v1/traces`. To use
+a different collector or proxy endpoint, pass `tcc_url` or set
+`TCC_LOCAL_OTLP_ENDPOINT`.

--- a/packages/python/contextcompany/config.py
+++ b/packages/python/contextcompany/config.py
@@ -3,6 +3,7 @@ from typing import Optional
 
 PROD_BASE = "https://api.thecontext.company"
 DEV_BASE = "https://dev.thecontext.company"
+DEFAULT_LOCAL_OTLP_ENDPOINT = "http://localhost:4318/v1/traces"
 
 
 def get_api_key(api_key: Optional[str] = None) -> str:
@@ -25,3 +26,7 @@ def get_base_url(api_key: Optional[str] = None) -> str:
 
 def get_url(path: str, api_key: Optional[str] = None) -> str:
     return f"{get_base_url(api_key)}{path}"
+
+
+def get_local_otlp_url(endpoint: Optional[str] = None) -> str:
+    return endpoint or os.getenv("TCC_LOCAL_OTLP_ENDPOINT", DEFAULT_LOCAL_OTLP_ENDPOINT)

--- a/packages/python/contextcompany/langchain/__init__.py
+++ b/packages/python/contextcompany/langchain/__init__.py
@@ -6,18 +6,24 @@ from opentelemetry.instrumentation.langchain import LangchainInstrumentor
 from opentelemetry.sdk.trace import TracerProvider
 
 from .base import setup_instrumentation
-from ..config import get_api_key, get_url
+from ..config import get_api_key, get_local_otlp_url, get_url
 from .._utils import _debug
 
 
 def instrument_langchain(
     api_key: Optional[str] = None,
     tcc_url: Optional[str] = None,
+    local: bool = False,
 ) -> TracerProvider:
-    resolved_api_key = get_api_key(api_key)
-    resolved_endpoint = tcc_url or get_url("/v1/traces", api_key=resolved_api_key)
+    if local:
+        resolved_api_key = api_key
+        resolved_endpoint = get_local_otlp_url(tcc_url)
+    else:
+        resolved_api_key = get_api_key(api_key)
+        resolved_endpoint = tcc_url or get_url("/v1/traces", api_key=resolved_api_key)
 
     _debug("Initializing LangChain instrumentation")
+    _debug(f"Local mode: {local}")
     _debug(f"Endpoint: {resolved_endpoint}")
 
     provider = setup_instrumentation(

--- a/packages/python/contextcompany/langchain/base.py
+++ b/packages/python/contextcompany/langchain/base.py
@@ -9,20 +9,26 @@ from .exporter import RunIdFixingExporter
 from .._utils import _debug
 
 
-def create_tracer_provider(resource_attributes: Optional[dict] = None) -> TracerProvider:
+def create_tracer_provider(
+    resource_attributes: Optional[dict] = None,
+) -> TracerProvider:
     resource = Resource(attributes=resource_attributes or {})
     return TracerProvider(resource=resource)
 
 
-def create_otlp_exporter(endpoint: str, api_key: str, headers: Optional[dict] = None) -> OTLPSpanExporter:
-    exporter_headers = {"Authorization": f"Bearer {api_key}"}
+def create_otlp_exporter(
+    endpoint: str, api_key: Optional[str] = None, headers: Optional[dict] = None
+) -> OTLPSpanExporter:
+    exporter_headers = {}
+    if api_key:
+        exporter_headers["Authorization"] = f"Bearer {api_key}"
     if headers:
         exporter_headers.update(headers)
     return OTLPSpanExporter(endpoint=endpoint, headers=exporter_headers)
 
 
 def setup_instrumentation(
-    api_key: str,
+    api_key: Optional[str],
     endpoint: str,
     resource_attributes: Optional[dict] = None,
 ) -> TracerProvider:
@@ -32,7 +38,9 @@ def setup_instrumentation(
 
     base_exporter = create_otlp_exporter(endpoint, api_key)
     fixing_exporter = RunIdFixingExporter(base_exporter)
-    batch_processor = TraceBatchSpanProcessor(exporter=fixing_exporter, timeout_seconds=600)
+    batch_processor = TraceBatchSpanProcessor(
+        exporter=fixing_exporter, timeout_seconds=600
+    )
 
     provider.add_span_processor(batch_processor)
     trace.set_tracer_provider(provider)

--- a/packages/python/tests/test_langchain_local.py
+++ b/packages/python/tests/test_langchain_local.py
@@ -1,0 +1,62 @@
+from unittest.mock import Mock
+
+import pytest
+
+from contextcompany.langchain import instrument_langchain
+from contextcompany.langchain import base
+
+
+def test_instrument_langchain_local_mode_does_not_require_api_key(monkeypatch):
+    setup = Mock(return_value="provider")
+    instrumentor = Mock()
+    monkeypatch.delenv("TCC_API_KEY", raising=False)
+    monkeypatch.delenv("TCC_LOCAL_OTLP_ENDPOINT", raising=False)
+    monkeypatch.setattr("contextcompany.langchain.setup_instrumentation", setup)
+    monkeypatch.setattr(
+        "contextcompany.langchain.LangchainInstrumentor",
+        Mock(return_value=instrumentor),
+    )
+
+    provider = instrument_langchain(local=True)
+
+    assert provider == "provider"
+    setup.assert_called_once_with(
+        api_key=None,
+        endpoint="http://localhost:4318/v1/traces",
+    )
+    instrumentor.instrument.assert_called_once_with()
+
+
+def test_instrument_langchain_local_mode_uses_explicit_endpoint(monkeypatch):
+    setup = Mock(return_value="provider")
+    monkeypatch.setattr("contextcompany.langchain.setup_instrumentation", setup)
+    monkeypatch.setattr(
+        "contextcompany.langchain.LangchainInstrumentor", Mock(return_value=Mock())
+    )
+
+    instrument_langchain(local=True, tcc_url="http://localhost:8787/v1/traces")
+
+    setup.assert_called_once_with(
+        api_key=None,
+        endpoint="http://localhost:8787/v1/traces",
+    )
+
+
+def test_instrument_langchain_cloud_mode_still_requires_api_key(monkeypatch):
+    monkeypatch.delenv("TCC_API_KEY", raising=False)
+
+    with pytest.raises(ValueError, match="TCC API key is required"):
+        instrument_langchain()
+
+
+def test_create_otlp_exporter_omits_authorization_without_api_key(monkeypatch):
+    exporter = Mock()
+    exporter_cls = Mock(return_value=exporter)
+    monkeypatch.setattr(base, "OTLPSpanExporter", exporter_cls)
+
+    result = base.create_otlp_exporter("http://localhost:4318/v1/traces")
+
+    assert result is exporter
+    exporter_cls.assert_called_once_with(
+        endpoint="http://localhost:4318/v1/traces", headers={}
+    )


### PR DESCRIPTION
## Summary

Part of #20.

This adds a scoped local-development path for the Python LangChain integration:

```python
from contextcompany.langchain import instrument_langchain

instrument_langchain(local=True)
```

In local mode, the SDK no longer requires `TCC_API_KEY`. It configures the LangChain OpenTelemetry exporter against a local OTLP HTTP endpoint instead:

- default: `http://localhost:4318/v1/traces`
- override with `tcc_url=...`
- or set `TCC_LOCAL_OTLP_ENDPOINT`

This does not attempt to solve the full local UI/collector story in one PR, but it removes the current cloud-auth hard stop for Python LangChain/LangGraph local development and makes it possible to run against a local collector/proxy without patching env vars or passing a fake API key.

## Changes

- Add `local: bool = False` to `instrument_langchain(...)`
- Allow `create_otlp_exporter(...)` to omit the `Authorization` header when no API key is provided
- Add `TCC_LOCAL_OTLP_ENDPOINT` / default local OTLP endpoint resolution
- Document Python LangChain local mode in `packages/python/README.md`
- Add regression tests for local mode, explicit local endpoint override, cloud-mode API key behavior, and auth-header omission

## Validation

- `/tmp/codex-observatory-venv/bin/python -m pytest packages/python/tests/test_langchain_local.py` -> `4 passed`
- `python -m ruff check packages/python/contextcompany/config.py packages/python/contextcompany/langchain/base.py packages/python/contextcompany/langchain/__init__.py packages/python/tests/test_langchain_local.py`
- `python -m ruff format --check packages/python/contextcompany/config.py packages/python/contextcompany/langchain/base.py packages/python/contextcompany/langchain/__init__.py packages/python/tests/test_langchain_local.py`
- `git diff --check`
