### PR TITLE
feat(custom): add full inputs functionality

### DIFF
--- a/.changeset/custom-prompt-full-input.md
+++ b/.changeset/custom-prompt-full-input.md
@@ -1,0 +1,7 @@
+---
+"@contextcompany/custom": minor
+---
+
+Add optional `full_input` on run prompts.
+
+Pass `full_input` alongside `user_prompt` (and optional `system_prompt`) to store the raw provider request body or message history verbatim for replay and debugging, while `user_prompt` continues to drive dashboard preview and search. Supported on `run().prompt()` and `RunInput.prompt`.

--- a/packages/ts/custom/README.md
+++ b/packages/ts/custom/README.md
@@ -154,7 +154,7 @@ Create a new run builder.
 
 | Method                      | Description                                              |
 | --------------------------- | -------------------------------------------------------- |
-| `.prompt(text)`             | Set the user prompt (required before `.end()`). Pass a string or `{ user_prompt, system_prompt? }`. |
+| `.prompt(text)`             | Set the user prompt (required before `.end()`). Pass a string or `{ user_prompt, system_prompt?, full_input? }`. `user_prompt` drives the dashboard preview/search; pass `full_input` to store the raw request body/history verbatim instead of overloading `user_prompt`. |
 | `.response(text)`           | Set the agent response                                   |
 | `.metadata({ key: "val" })` | Attach metadata key-value pairs                          |
 | `.status(code, message?)`   | Set status (0 = success, 2 = error)                      |

--- a/packages/ts/custom/src/run.ts
+++ b/packages/ts/custom/src/run.ts
@@ -38,8 +38,9 @@ export class Run {
   private _startTime: string;
   private _endTime: string | null = null;
 
-  private _prompt: { user_prompt: string; system_prompt?: string } | undefined =
-    undefined;
+  private _prompt:
+    | { user_prompt: string; system_prompt?: string; full_input?: string }
+    | undefined = undefined;
   private _response: string | null = null;
 
   private _statusCode = 0;
@@ -85,23 +86,33 @@ export class Run {
    * Must be called before {@link Run.end | .end()}.
    *
    * Pass a string for user prompt only, or an object for user + optional
-   * system prompt.
+   * system prompt. Provide `full_input` to store the raw input (e.g. the
+   * complete provider request body or message history) verbatim while
+   * `user_prompt` drives the dashboard preview/search — prefer this over
+   * passing a JSON blob as `user_prompt`.
    *
    * @example
    * ```ts
    * r.prompt("What's the weather?");
    * r.prompt({ user_prompt: "Summarize this", system_prompt: "You are a helpful assistant." });
+   * r.prompt({ user_prompt: "Reset my password", full_input: JSON.stringify(requestBody) });
    * ```
    *
    * @returns `this` for chaining.
    */
   prompt(
-    input: string | { user_prompt: string; system_prompt?: string }
+    input:
+      | string
+      | { user_prompt: string; system_prompt?: string; full_input?: string }
   ): this {
     this._prompt =
       typeof input === "string"
         ? { user_prompt: input }
-        : { user_prompt: input.user_prompt, system_prompt: input.system_prompt };
+        : {
+            user_prompt: input.user_prompt,
+            system_prompt: input.system_prompt,
+            full_input: input.full_input,
+          };
     return this;
   }
 

--- a/packages/ts/custom/src/types.ts
+++ b/packages/ts/custom/src/types.ts
@@ -134,8 +134,19 @@ export type RunInput = {
   sessionId?: string;
   /** Whether this run is part of a multi-turn conversation. */
   conversational?: boolean;
-  /** The user prompt / input that initiated the run. Optionally include a system prompt. */
-  prompt: { user_prompt: string; system_prompt?: string };
+  /**
+   * The user prompt / input that initiated the run.
+   *
+   * - `user_prompt` is the canonical user message. It drives the dashboard
+   *   preview, search, and session views, so keep it to the actual request
+   *   text — not a full request body or injected context.
+   * - `system_prompt` is the optional system instruction.
+   * - `full_input` is the optional raw input (e.g. the complete provider
+   *   request body or message history). When provided, it is stored verbatim
+   *   for replay/debugging while `user_prompt` is used for the preview. Prefer
+   *   this over stuffing a JSON blob into `user_prompt`.
+   */
+  prompt: { user_prompt: string; system_prompt?: string; full_input?: string };
   /** The agent's final response. */
   response?: string;
   /** When the run started (ISO-8601 string or `Date`). */


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Backward-compatible optional field on prompt types and ingestion payload shape; no auth or core logic changes in this diff.
> 
> **Overview**
> Adds an optional **`full_input`** field on run prompts in `@contextcompany/custom`, so integrators can send the raw provider request body or full message history while keeping **`user_prompt`** as the short text used for dashboard preview and search.
> 
> **`Run.prompt()`** and **`RunInput.prompt`** now accept `{ user_prompt, system_prompt?, full_input? }`; the builder stores and forwards `full_input` on the run payload when set. README, JSDoc, and a minor changeset document the split and recommend `full_input` instead of stuffing JSON into `user_prompt`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0cab8875ef09e4bd5c0e4277bb2b1dc34b1e1206. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->