### PR TITLE
feat(custom): enhance response handling to include full model output

### DIFF
--- a/.changeset/custom-response-full-output.md
+++ b/.changeset/custom-response-full-output.md
@@ -1,0 +1,7 @@
+---
+"@contextcompany/custom": minor
+---
+
+Add optional `full_output` on run responses.
+
+Pass `full_output` alongside `response` to store the raw/full model output (e.g. the final assistant message including tool_use blocks, or a reply delivered via a tool call) verbatim for replay and debugging, while `response` continues to drive dashboard preview and search. Supported on `run().response()` and `RunInput.response`.

--- a/.changeset/custom-response-stale-full-output.md
+++ b/.changeset/custom-response-stale-full-output.md
@@ -1,0 +1,5 @@
+---
+"@contextcompany/custom": patch
+---
+
+Fix stale `full_output` on `run().response()`. Calling `.response()` with a string after a prior call set `full_output` now clears the previous value, so the run payload no longer carries replay/debug output that doesn't match the visible reply.

--- a/packages/ts/custom/README.md
+++ b/packages/ts/custom/README.md
@@ -155,7 +155,7 @@ Create a new run builder.
 | Method                      | Description                                              |
 | --------------------------- | -------------------------------------------------------- |
 | `.prompt(text)`             | Set the user prompt (required before `.end()`). Pass a string or `{ user_prompt, system_prompt?, full_input? }`. `user_prompt` drives the dashboard preview/search; pass `full_input` to store the raw request body/history verbatim instead of overloading `user_prompt`. |
-| `.response(text)`           | Set the agent response                                   |
+| `.response(text)`           | Set the agent response. Pass a string or `{ response, full_output? }`. `response` is the human-visible reply that drives the dashboard preview/search; pass `full_output` to store the raw/full model output (e.g. the final assistant message or a reply delivered via a tool call) verbatim instead of overloading `response`. |
 | `.metadata({ key: "val" })` | Attach metadata key-value pairs                          |
 | `.status(code, message?)`   | Set status (0 = success, 2 = error)                      |
 | `.endTime(date)`            | Set a custom end time                                    |

--- a/packages/ts/custom/src/run.ts
+++ b/packages/ts/custom/src/run.ts
@@ -139,6 +139,7 @@ export class Run {
   ): this {
     if (typeof input === "string") {
       this._response = input;
+      this._fullOutput = null;
     } else {
       this._response = input.response;
       this._fullOutput = input.full_output ?? null;

--- a/packages/ts/custom/src/run.ts
+++ b/packages/ts/custom/src/run.ts
@@ -42,6 +42,7 @@ export class Run {
     | { user_prompt: string; system_prompt?: string; full_input?: string }
     | undefined = undefined;
   private _response: string | null = null;
+  private _fullOutput: string | null = null;
 
   private _statusCode = 0;
   private _statusMessage: string | null = null;
@@ -119,10 +120,29 @@ export class Run {
   /**
    * Set the agent's final response to the user.
    *
+   * Pass a string for the visible reply, or an object to additionally provide
+   * `full_output` — the raw/full model output (e.g. the final assistant
+   * message including tool_use blocks, or a reply delivered via a tool call)
+   * stored verbatim for replay while `response` drives the dashboard
+   * preview/search. Prefer this over stuffing a JSON blob into `response`.
+   *
+   * @example
+   * ```ts
+   * r.response("72°F in San Francisco.");
+   * r.response({ response: "72°F in San Francisco.", full_output: JSON.stringify(assistantMessage) });
+   * ```
+   *
    * @returns `this` for chaining.
    */
-  response(text: string): this {
-    this._response = text;
+  response(
+    input: string | { response: string; full_output?: string }
+  ): this {
+    if (typeof input === "string") {
+      this._response = input;
+    } else {
+      this._response = input.response;
+      this._fullOutput = input.full_output ?? null;
+    }
     return this;
   }
 
@@ -314,6 +334,7 @@ export class Run {
     if (this._conversational !== null)
       payload.conversational = this._conversational;
     if (this._response !== null) payload.response = this._response;
+    if (this._fullOutput !== null) payload.full_output = this._fullOutput;
     if (this._statusMessage !== null)
       payload.status_message = this._statusMessage;
     if (this._metadata !== null) payload.metadata = this._metadata;

--- a/packages/ts/custom/src/send.ts
+++ b/packages/ts/custom/src/send.ts
@@ -36,6 +36,7 @@ function buildRunPayload(
   if (input.conversational !== undefined)
     payload.conversational = input.conversational;
   if (input.response !== undefined) payload.response = input.response;
+  if (input.full_output !== undefined) payload.full_output = input.full_output;
   if (input.statusMessage !== undefined)
     payload.status_message = input.statusMessage;
   if (input.metadata !== undefined) payload.metadata = input.metadata;

--- a/packages/ts/custom/src/types.ts
+++ b/packages/ts/custom/src/types.ts
@@ -147,8 +147,20 @@ export type RunInput = {
    *   this over stuffing a JSON blob into `user_prompt`.
    */
   prompt: { user_prompt: string; system_prompt?: string; full_input?: string };
-  /** The agent's final response. */
+  /**
+   * The agent's final response.
+   *
+   * - `response` is the human-visible reply. It drives the dashboard
+   *   preview/search, so keep it to the actual reply text — not a full
+   *   model output or tool-call envelope.
+   * - `full_output` is the optional raw/full model output (e.g. the final
+   *   assistant message including tool_use blocks, or a reply delivered via a
+   *   tool call). When provided, it is stored verbatim for replay/debugging
+   *   while `response` is used for the preview. Prefer this over stuffing a
+   *   JSON blob into `response`.
+   */
   response?: string;
+  full_output?: string;
   /** When the run started (ISO-8601 string or `Date`). */
   startTime: Date | string;
   /** When the run finished (ISO-8601 string or `Date`). */


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> SDK-only observability field additions with backward-compatible APIs; no auth or server logic in this diff.
> 
> **Overview**
> Adds optional **`full_output`** on run responses in `@contextcompany/custom`, mirroring the existing **`full_input`** split: **`response`** stays the human-visible text for dashboard preview/search, while **`full_output`** stores raw model output verbatim for replay and debugging.
> 
> **`run().response()`** now accepts a string or `{ response, full_output? }`; a later string-only call clears any previous **`full_output`** so payloads cannot show stale replay data. **`RunInput`** / **`sendRun`** gain **`full_output`**, and docs/changesets describe the behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e256deb4f799c8937ef3c093947510962b9c5073. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->