### PR TITLE
Add npm install script hardening

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+ignore-scripts=true


### PR DESCRIPTION
Adds a repo-root npm config to prevent dependency lifecycle scripts from running automatically during install, addressing the Oneleet npm ignore-scripts finding.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single npm config flag with no application or auth logic changes; low risk unless the project depended on postinstall scripts for builds or native addons.
> 
> **Overview**
> Adds a repo-root **`.npmrc`** with **`ignore-scripts=true`** so **`npm install`** (and related installs) no longer runs dependency **lifecycle scripts** (`preinstall`, `postinstall`, etc.) by default.
> 
> This hardens installs against supply-chain scripts while keeping normal package resolution and installs unchanged; teams that rely on a package’s install scripts would need to run them explicitly or adjust config.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 542bbc5a8f44abaaa0f2582b0aabd0a84687e078. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->