### PR TITLE
Add npm hardening for Mastra example

### DIFF
--- a/examples/mastra/.npmrc
+++ b/examples/mastra/.npmrc
@@ -1,0 +1,1 @@
+ignore-scripts=true


### PR DESCRIPTION
Adds an .npmrc next to examples/mastra/package-lock.json to disable npm lifecycle scripts for that package-lock, addressing the remaining Oneleet npm ignore-scripts finding.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only change with no runtime or application logic impact.
> 
> **Overview**
> Adds **`examples/mastra/.npmrc`** with **`ignore-scripts=true`** so npm skips install lifecycle scripts when dependencies are installed from that example’s lockfile.
> 
> This mirrors the repo’s npm hardening pattern and closes the remaining **Oneleet** finding for the Mastra example package-lock.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3c59f5fe77f8db2b9c0087898a3e1c2d711f6f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->