### PR TITLE
fix: address pentest findings

### DIFF
--- a/.changeset/bounded-otel-batches.md
+++ b/.changeset/bounded-otel-batches.md
@@ -1,0 +1,5 @@
+---
+"@contextcompany/otel": patch
+---
+
+Bound active run batches, queued spans, and timeout state in the run batch span processor to reduce local memory exhaustion risk.

--- a/.changeset/liftoff-api-base-allowlist.md
+++ b/.changeset/liftoff-api-base-allowlist.md
@@ -1,0 +1,5 @@
+---
+"@contextcompany/liftoff": patch
+---
+
+Restrict Liftoff API base overrides to official TCC origins or localhost by default, with an explicit unsafe override for self-hosted testing.

--- a/.changeset/redact-status-messages.md
+++ b/.changeset/redact-status-messages.md
@@ -1,0 +1,5 @@
+---
+"@contextcompany/custom": patch
+---
+
+Redact secrets from custom TypeScript status messages before sending runs, steps, tool calls, and direct event payloads.

--- a/.changeset/secure-feedback-api.md
+++ b/.changeset/secure-feedback-api.md
@@ -1,0 +1,12 @@
+---
+"@contextcompany/api": patch
+"@contextcompany/custom": patch
+"@contextcompany/otel": patch
+"@contextcompany/claude": patch
+"@contextcompany/mastra": patch
+"@contextcompany/langchain": patch
+"@contextcompany/openclaw": patch
+"@contextcompany/pi": patch
+---
+
+Harden feedback submission by validating run IDs before sending feedback and restricting configurable TCC API endpoints to official origins or localhost by default.

--- a/.changeset/secure-local-widget.md
+++ b/.changeset/secure-local-widget.md
@@ -1,0 +1,6 @@
+---
+"@contextcompany/otel": patch
+"@contextcompany/widget": patch
+---
+
+Secure the local development widget WebSocket by binding to localhost, requiring a per-process token, validating local origins, and ignoring malformed telemetry events.

--- a/packages/python/contextcompany/redaction.py
+++ b/packages/python/contextcompany/redaction.py
@@ -1,0 +1,37 @@
+import re
+
+_SECRET_ASSIGNMENT_PATTERN = re.compile(
+    r"\b(api[_-]?key|access[_-]?token|refresh[_-]?token|id[_-]?token|client[_-]?secret|secret|password|passwd|pwd|authorization|bearer)\b\s*[:=]\s*([^\s\"',;})\]]+)\]?",
+    re.IGNORECASE,
+)
+
+_SECRET_VALUE_PATTERNS = [
+    re.compile(r"\bsk-(?:proj-)?[A-Za-z0-9_-]{16,}\b"),
+    re.compile(r"\bxox[abprs]-[A-Za-z0-9-]{16,}\b"),
+    re.compile(r"\bgh[pousr]_[A-Za-z0-9_]{16,}\b"),
+    re.compile(r"\bservice_[A-Za-z0-9_-]{16,}\b"),
+]
+
+
+def redact_status_message(message: str) -> str:
+    redacted = re.sub(
+        r"\bAuthorization\s*[:=]\s*Bearer\s+([^\s\"',;})\]]+)\]?",
+        "Authorization=[REDACTED]",
+        message,
+        flags=re.IGNORECASE,
+    )
+    redacted = re.sub(
+        r"\bAuthorization\s*[:=]\s*Basic\s+([A-Za-z0-9+/=]{12,})\]?",
+        "Authorization=[REDACTED]",
+        redacted,
+        flags=re.IGNORECASE,
+    )
+    redacted = re.sub(r"\bBearer\s+([^\s\"',;})\]]+)\]?", "Bearer [REDACTED]", redacted, flags=re.IGNORECASE)
+    redacted = re.sub(r"\bBasic\s+([A-Za-z0-9+/=]{12,})\]?", "Basic [REDACTED]", redacted, flags=re.IGNORECASE)
+    redacted = _SECRET_ASSIGNMENT_PATTERN.sub(lambda match: f"{match.group(1)}=[REDACTED]", redacted)
+    redacted = re.sub(r"https?://([^/\s:@]+):([^@\s/]+)@", r"https://\1:[REDACTED]@", redacted, flags=re.IGNORECASE)
+
+    for pattern in _SECRET_VALUE_PATTERNS:
+        redacted = pattern.sub("[REDACTED]", redacted)
+
+    return redacted

--- a/packages/python/contextcompany/run.py
+++ b/packages/python/contextcompany/run.py
@@ -3,6 +3,7 @@ import uuid
 from typing import Any, Dict, Literal, Optional
 
 from ._utils import _now_iso, _SENTINEL, _debug, _send_payload
+from .redaction import redact_status_message
 
 
 class Run:
@@ -72,7 +73,7 @@ class Run:
     def status(self, code: int, message: Optional[str] = None) -> "Run":
         self._status_code = code
         if message is not None:
-            self._status_message = message
+            self._status_message = redact_status_message(message)
         _debug("Run status set:", code, message)
         return self
 
@@ -105,7 +106,7 @@ class Run:
         _debug("Run error:", status_message)
         self._status_code = 2
         if status_message:
-            self._status_message = status_message
+            self._status_message = redact_status_message(status_message)
         self._ended = True
 
         payload = self._build_payload()

--- a/packages/python/contextcompany/step.py
+++ b/packages/python/contextcompany/step.py
@@ -2,6 +2,7 @@ import uuid
 from typing import Any, Dict, Optional
 
 from ._utils import _now_iso, _SENTINEL, _debug, _send_payload
+from .redaction import redact_status_message
 
 
 class Step:
@@ -107,7 +108,7 @@ class Step:
     def status(self, code: int, message: Optional[str] = None) -> "Step":
         self._status_code = code
         if message is not None:
-            self._status_message = message
+            self._status_message = redact_status_message(message)
         _debug("Step status set:", code, message)
         return self
 
@@ -118,7 +119,7 @@ class Step:
         _debug("Step error:", status_message)
         self._status_code = 2
         if status_message:
-            self._status_message = status_message
+            self._status_message = redact_status_message(status_message)
         self._ended = True
 
         payload = self._build_payload()

--- a/packages/python/contextcompany/tool_call.py
+++ b/packages/python/contextcompany/tool_call.py
@@ -3,6 +3,7 @@ import uuid
 from typing import Any, Dict, Optional, Union
 
 from ._utils import _now_iso, _debug, _send_payload
+from .redaction import redact_status_message
 
 
 class ToolCall:
@@ -54,7 +55,7 @@ class ToolCall:
     def status(self, code: int, message: Optional[str] = None) -> "ToolCall":
         self._status_code = code
         if message is not None:
-            self._status_message = message
+            self._status_message = redact_status_message(message)
         _debug("ToolCall status set:", code, message)
         return self
 
@@ -65,7 +66,7 @@ class ToolCall:
         _debug("ToolCall error:", status_message)
         self._status_code = 2
         if status_message:
-            self._status_message = status_message
+            self._status_message = redact_status_message(status_message)
         self._ended = True
 
         payload = self._build_payload()

--- a/packages/ts/api/src/config.test.ts
+++ b/packages/ts/api/src/config.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, afterEach } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import { normalizeTCCBaseUrl } from "./config";
 
 const OLD_ENV = process.env.TCC_ALLOW_UNSAFE_BASE_URL;
@@ -12,6 +12,9 @@ describe("normalizeTCCBaseUrl", () => {
   it("allows official TCC origins", () => {
     expect(normalizeTCCBaseUrl("https://api.thecontext.company/")).toBe(
       "https://api.thecontext.company"
+    );
+    expect(normalizeTCCBaseUrl("https://api.thecontext.company/v1")).toBe(
+      "https://api.thecontext.company/v1"
     );
     expect(normalizeTCCBaseUrl("https://dev.thecontext.company")).toBe(
       "https://dev.thecontext.company"

--- a/packages/ts/api/src/config.test.ts
+++ b/packages/ts/api/src/config.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it, afterEach } from "vitest";
+import { normalizeTCCBaseUrl } from "./config";
+
+const OLD_ENV = process.env.TCC_ALLOW_UNSAFE_BASE_URL;
+
+afterEach(() => {
+  if (OLD_ENV === undefined) delete process.env.TCC_ALLOW_UNSAFE_BASE_URL;
+  else process.env.TCC_ALLOW_UNSAFE_BASE_URL = OLD_ENV;
+});
+
+describe("normalizeTCCBaseUrl", () => {
+  it("allows official TCC origins", () => {
+    expect(normalizeTCCBaseUrl("https://api.thecontext.company/")).toBe(
+      "https://api.thecontext.company"
+    );
+    expect(normalizeTCCBaseUrl("https://dev.thecontext.company")).toBe(
+      "https://dev.thecontext.company"
+    );
+  });
+
+  it("allows localhost for development", () => {
+    expect(normalizeTCCBaseUrl("http://localhost:8787/")).toBe(
+      "http://localhost:8787"
+    );
+  });
+
+  it("rejects arbitrary remote origins unless explicitly allowed", () => {
+    expect(() => normalizeTCCBaseUrl("https://evil.example")).toThrow(
+      /Refusing unsafe/
+    );
+
+    process.env.TCC_ALLOW_UNSAFE_BASE_URL = "1";
+    expect(normalizeTCCBaseUrl("https://self-hosted.example/")).toBe(
+      "https://self-hosted.example"
+    );
+  });
+});

--- a/packages/ts/api/src/config.ts
+++ b/packages/ts/api/src/config.ts
@@ -1,5 +1,39 @@
 const PROD_BASE = "https://api.thecontext.company";
 const DEV_BASE = "https://dev.thecontext.company";
+const ALLOWED_REMOTE_ORIGINS = new Set([PROD_BASE, DEV_BASE]);
+
+function isUnsafeBaseUrlAllowed(): boolean {
+  return (
+    typeof process !== "undefined" &&
+    process.env?.TCC_ALLOW_UNSAFE_BASE_URL === "1"
+  );
+}
+
+function isLocalhostOrigin(origin: string): boolean {
+  return /^https?:\/\/(localhost|127\.0\.0\.1|\[::1\])(:\d+)?$/.test(origin);
+}
+
+export function normalizeTCCBaseUrl(url: string): string {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new Error(`[TCC] Invalid TCC base URL: ${url}`);
+  }
+
+  const base = parsed.origin + parsed.pathname.replace(/\/+$/, "");
+  if (ALLOWED_REMOTE_ORIGINS.has(base) || isLocalhostOrigin(parsed.origin)) {
+    return base;
+  }
+
+  if (isUnsafeBaseUrlAllowed()) {
+    return base;
+  }
+
+  throw new Error(
+    `[TCC] Refusing unsafe TCC base URL (${base}). Use ${PROD_BASE}, ${DEV_BASE}, localhost, or set TCC_ALLOW_UNSAFE_BASE_URL=1 for self-hosted testing.`
+  );
+}
 
 /**
  * Get TCC API key from environment
@@ -17,7 +51,7 @@ export function getTCCApiKey(): string | undefined {
  */
 export function getTCCBaseUrl(apiKey?: string): string {
   if (typeof process !== "undefined" && process.env?.TCC_BASE_URL) {
-    return process.env.TCC_BASE_URL.replace(/\/+$/, "");
+    return normalizeTCCBaseUrl(process.env.TCC_BASE_URL);
   }
   const envApiKey =
     typeof process !== "undefined" && process.env
@@ -44,5 +78,10 @@ export function getTCCFeedbackUrl(): string {
     typeof process !== "undefined" && process.env
       ? process.env.TCC_FEEDBACK_URL
       : undefined;
-  return envUrl ?? `${getTCCBaseUrl()}/v1/feedback`;
+  if (envUrl) {
+    const url = new URL(envUrl);
+    const base = normalizeTCCBaseUrl(url.origin + url.pathname.replace(/\/v1\/feedback\/?$/, ""));
+    return `${base}/v1/feedback`;
+  }
+  return `${getTCCBaseUrl()}/v1/feedback`;
 }

--- a/packages/ts/api/src/config.ts
+++ b/packages/ts/api/src/config.ts
@@ -22,7 +22,10 @@ export function normalizeTCCBaseUrl(url: string): string {
   }
 
   const base = parsed.origin + parsed.pathname.replace(/\/+$/, "");
-  if (ALLOWED_REMOTE_ORIGINS.has(base) || isLocalhostOrigin(parsed.origin)) {
+  if (
+    ALLOWED_REMOTE_ORIGINS.has(parsed.origin) ||
+    isLocalhostOrigin(parsed.origin)
+  ) {
     return base;
   }
 
@@ -80,7 +83,9 @@ export function getTCCFeedbackUrl(): string {
       : undefined;
   if (envUrl) {
     const url = new URL(envUrl);
-    const base = normalizeTCCBaseUrl(url.origin + url.pathname.replace(/\/v1\/feedback\/?$/, ""));
+    const base = normalizeTCCBaseUrl(
+      url.origin + url.pathname.replace(/\/v1\/feedback\/?$/, "")
+    );
     return `${base}/v1/feedback`;
   }
   return `${getTCCBaseUrl()}/v1/feedback`;

--- a/packages/ts/api/src/feedback.ts
+++ b/packages/ts/api/src/feedback.ts
@@ -3,6 +3,15 @@ export async function submitFeedback(params: {
   score?: "thumbs_up" | "thumbs_down";
   text?: string;
 }): Promise<Response | undefined> {
+  if (
+    !/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(
+      params.runId
+    )
+  ) {
+    console.error("[TCC] Cannot submit feedback: runId must be a UUID");
+    return;
+  }
+
   if (!params.score && !params.text) {
     console.error(
       "[TCC] Cannot submit feedback: at least one of 'score' or 'text' must be provided"

--- a/packages/ts/api/vitest.config.ts
+++ b/packages/ts/api/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["src/**/*.{test,spec}.?(c|m)[jt]s?(x)"],
+  },
+});

--- a/packages/ts/custom/src/redaction.ts
+++ b/packages/ts/custom/src/redaction.ts
@@ -1,0 +1,25 @@
+const SECRET_ASSIGNMENT_PATTERN =
+  /\b(api[_-]?key|access[_-]?token|refresh[_-]?token|id[_-]?token|client[_-]?secret|secret|password|passwd|pwd|authorization|bearer)\b\s*[:=]\s*([^\s"',;})\]]+)\]?/gi;
+
+const SECRET_VALUE_PATTERNS = [
+  /\bsk-(?:proj-)?[A-Za-z0-9_-]{16,}\b/g,
+  /\bxox[abprs]-[A-Za-z0-9-]{16,}\b/g,
+  /\bgh[pousr]_[A-Za-z0-9_]{16,}\b/g,
+  /\bservice_[A-Za-z0-9_-]{16,}\b/g,
+];
+
+export function redactStatusMessage(message: string): string {
+  let redacted = message
+    .replace(/\bAuthorization\s*[:=]\s*Bearer\s+([^\s"',;})\]]+)\]?/gi, "Authorization=[REDACTED]")
+    .replace(/\bAuthorization\s*[:=]\s*Basic\s+([A-Za-z0-9+/=]{12,})\]?/gi, "Authorization=[REDACTED]")
+    .replace(/\bBearer\s+([^\s"',;})\]]+)\]?/gi, "Bearer [REDACTED]")
+    .replace(/\bBasic\s+([A-Za-z0-9+/=]{12,})\]?/gi, "Basic [REDACTED]")
+    .replace(SECRET_ASSIGNMENT_PATTERN, (_match, key) => `${key}=[REDACTED]`)
+    .replace(/https?:\/\/([^/\s:@]+):([^@\s/]+)@/gi, "https://$1:[REDACTED]@");
+
+  for (const pattern of SECRET_VALUE_PATTERNS) {
+    redacted = redacted.replace(pattern, "[REDACTED]");
+  }
+
+  return redacted;
+}

--- a/packages/ts/custom/src/run.ts
+++ b/packages/ts/custom/src/run.ts
@@ -1,4 +1,5 @@
 import { getConfig } from "./config";
+import { redactStatusMessage } from "./redaction";
 import { Step } from "./step";
 import { ToolCall } from "./tool-call";
 import { debug, send } from "./transport";
@@ -176,7 +177,7 @@ export class Run {
    */
   status(code: number, message?: string): this {
     this._statusCode = code;
-    if (message !== undefined) this._statusMessage = message;
+    if (message !== undefined) this._statusMessage = redactStatusMessage(message);
     return this;
   }
 
@@ -247,7 +248,7 @@ export class Run {
     if (this._ended) throw new Error("[TCC] Run already ended");
     this._clearTimeout();
     this._statusCode = 2;
-    if (message) this._statusMessage = message;
+    if (message) this._statusMessage = redactStatusMessage(message);
     this._ended = true;
     this._endTime ??= new Date().toISOString();
 

--- a/packages/ts/custom/src/send.ts
+++ b/packages/ts/custom/src/send.ts
@@ -1,3 +1,4 @@
+import { redactStatusMessage } from "./redaction";
 import type { RunInput, StepInput, ToolCallInput, ModelConfig } from "./types";
 import { send, debug } from "./transport";
 
@@ -38,7 +39,7 @@ function buildRunPayload(
   if (input.response !== undefined) payload.response = input.response;
   if (input.full_output !== undefined) payload.full_output = input.full_output;
   if (input.statusMessage !== undefined)
-    payload.status_message = input.statusMessage;
+    payload.status_message = redactStatusMessage(input.statusMessage);
   if (input.metadata !== undefined) payload.metadata = input.metadata;
 
   return payload;
@@ -60,7 +61,7 @@ function buildStepPayload(
   };
 
   if (input.statusMessage !== undefined)
-    payload.status_message = input.statusMessage;
+    payload.status_message = redactStatusMessage(input.statusMessage);
 
   if (input.model !== undefined) {
     const { requested, used } = resolveModel(input.model);
@@ -98,7 +99,7 @@ function buildToolCallPayload(
   };
 
   if (input.statusMessage !== undefined)
-    payload.status_message = input.statusMessage;
+    payload.status_message = redactStatusMessage(input.statusMessage);
   if (input.args !== undefined) payload.args = stringify(input.args);
   if (input.result !== undefined) payload.result = stringify(input.result);
 

--- a/packages/ts/custom/src/step.ts
+++ b/packages/ts/custom/src/step.ts
@@ -1,3 +1,4 @@
+import { redactStatusMessage } from "./redaction";
 import type { StepOptions, TokenUsage, ModelConfig } from "./types";
 import { debug } from "./transport";
 
@@ -182,7 +183,7 @@ export class Step {
    */
   status(code: number, message?: string): this {
     this._statusCode = code;
-    if (message !== undefined) this._statusMessage = message;
+    if (message !== undefined) this._statusMessage = redactStatusMessage(message);
     return this;
   }
 
@@ -206,7 +207,7 @@ export class Step {
   error(message = ""): void {
     if (this._ended) throw new Error("[TCC] Step already ended");
     this._statusCode = 2;
-    if (message) this._statusMessage = message;
+    if (message) this._statusMessage = redactStatusMessage(message);
     this._ended = true;
     this._endTime ??= new Date().toISOString();
     debug("Step error", { stepId: this._stepId, message });

--- a/packages/ts/custom/src/tool-call.ts
+++ b/packages/ts/custom/src/tool-call.ts
@@ -1,3 +1,4 @@
+import { redactStatusMessage } from "./redaction";
 import type { ToolCallOptions } from "./types";
 import { debug } from "./transport";
 
@@ -124,7 +125,7 @@ export class ToolCall {
    */
   status(code: number, message?: string): this {
     this._statusCode = code;
-    if (message !== undefined) this._statusMessage = message;
+    if (message !== undefined) this._statusMessage = redactStatusMessage(message);
     return this;
   }
 
@@ -137,7 +138,7 @@ export class ToolCall {
   error(message = ""): void {
     if (this._ended) throw new Error("[TCC] ToolCall already ended");
     this._statusCode = 2;
-    if (message) this._statusMessage = message;
+    if (message) this._statusMessage = redactStatusMessage(message);
     this._ended = true;
     this._endTime ??= new Date().toISOString();
     debug("ToolCall error", { toolCallId: this._toolCallId, message });

--- a/packages/ts/liftoff/src/utils/config.test.ts
+++ b/packages/ts/liftoff/src/utils/config.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { getApiBase, setApiBase } from "./config";
+
+const OLD_ENV = {
+  TCC_BASE_URL: process.env.TCC_BASE_URL,
+  TCC_ALLOW_UNSAFE_BASE_URL: process.env.TCC_ALLOW_UNSAFE_BASE_URL,
+};
+
+afterEach(() => {
+  setApiBase(undefined);
+  if (OLD_ENV.TCC_BASE_URL === undefined) delete process.env.TCC_BASE_URL;
+  else process.env.TCC_BASE_URL = OLD_ENV.TCC_BASE_URL;
+  if (OLD_ENV.TCC_ALLOW_UNSAFE_BASE_URL === undefined) {
+    delete process.env.TCC_ALLOW_UNSAFE_BASE_URL;
+  } else {
+    process.env.TCC_ALLOW_UNSAFE_BASE_URL =
+      OLD_ENV.TCC_ALLOW_UNSAFE_BASE_URL;
+  }
+});
+
+describe("liftoff API base config", () => {
+  it("accepts official and localhost bases", () => {
+    setApiBase("https://api.thecontext.company/");
+    expect(getApiBase()).toBe("https://api.thecontext.company");
+
+    setApiBase("http://localhost:8787/");
+    expect(getApiBase()).toBe("http://localhost:8787");
+  });
+
+  it("rejects arbitrary --api-base values by default", () => {
+    expect(() => setApiBase("https://evil.example")).toThrow(
+      /Refusing unsafe/
+    );
+  });
+
+  it("allows explicit unsafe override for self-hosted testing", () => {
+    process.env.TCC_ALLOW_UNSAFE_BASE_URL = "1";
+    setApiBase("https://self-hosted.example/");
+    expect(getApiBase()).toBe("https://self-hosted.example");
+  });
+});

--- a/packages/ts/liftoff/src/utils/config.test.ts
+++ b/packages/ts/liftoff/src/utils/config.test.ts
@@ -13,8 +13,7 @@ afterEach(() => {
   if (OLD_ENV.TCC_ALLOW_UNSAFE_BASE_URL === undefined) {
     delete process.env.TCC_ALLOW_UNSAFE_BASE_URL;
   } else {
-    process.env.TCC_ALLOW_UNSAFE_BASE_URL =
-      OLD_ENV.TCC_ALLOW_UNSAFE_BASE_URL;
+    process.env.TCC_ALLOW_UNSAFE_BASE_URL = OLD_ENV.TCC_ALLOW_UNSAFE_BASE_URL;
   }
 });
 
@@ -23,14 +22,15 @@ describe("liftoff API base config", () => {
     setApiBase("https://api.thecontext.company/");
     expect(getApiBase()).toBe("https://api.thecontext.company");
 
+    setApiBase("https://api.thecontext.company/v1");
+    expect(getApiBase()).toBe("https://api.thecontext.company/v1");
+
     setApiBase("http://localhost:8787/");
     expect(getApiBase()).toBe("http://localhost:8787");
   });
 
   it("rejects arbitrary --api-base values by default", () => {
-    expect(() => setApiBase("https://evil.example")).toThrow(
-      /Refusing unsafe/
-    );
+    expect(() => setApiBase("https://evil.example")).toThrow(/Refusing unsafe/);
   });
 
   it("allows explicit unsafe override for self-hosted testing", () => {

--- a/packages/ts/liftoff/src/utils/config.ts
+++ b/packages/ts/liftoff/src/utils/config.ts
@@ -26,7 +26,11 @@ function normalizeApiBase(url: string): string {
   const isLocalhost =
     /^https?:\/\/(localhost|127\.0\.0\.1|\[::1\])(:\d+)?$/.test(parsed.origin);
 
-  if (ALLOWED_REMOTE_BASES.has(base) || isLocalhost || unsafeApiBaseAllowed()) {
+  if (
+    ALLOWED_REMOTE_BASES.has(parsed.origin) ||
+    isLocalhost ||
+    unsafeApiBaseAllowed()
+  ) {
     return base;
   }
 

--- a/packages/ts/liftoff/src/utils/config.ts
+++ b/packages/ts/liftoff/src/utils/config.ts
@@ -4,17 +4,46 @@
 // (3) prod default.
 
 const DEFAULT_API_BASE = "https://api.thecontext.company";
+const DEV_API_BASE = "https://dev.thecontext.company";
 const DEFAULT_DASHBOARD_URL = "https://www.thecontext.company";
+const ALLOWED_REMOTE_BASES = new Set([DEFAULT_API_BASE, DEV_API_BASE]);
 
 let overrideApiBase: string | undefined;
 
+function unsafeApiBaseAllowed(): boolean {
+  return process.env.TCC_ALLOW_UNSAFE_BASE_URL === "1";
+}
+
+function normalizeApiBase(url: string): string {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new Error(`[TCC] Invalid --api-base URL: ${url}`);
+  }
+
+  const base = parsed.origin + parsed.pathname.replace(/\/+$/, "");
+  const isLocalhost =
+    /^https?:\/\/(localhost|127\.0\.0\.1|\[::1\])(:\d+)?$/.test(parsed.origin);
+
+  if (ALLOWED_REMOTE_BASES.has(base) || isLocalhost || unsafeApiBaseAllowed()) {
+    return base;
+  }
+
+  throw new Error(
+    `[TCC] Refusing unsafe --api-base (${base}). Use ${DEFAULT_API_BASE}, ${DEV_API_BASE}, localhost, or set TCC_ALLOW_UNSAFE_BASE_URL=1 for self-hosted testing.`
+  );
+}
+
 export function setApiBase(url: string | undefined): void {
-  overrideApiBase = url?.replace(/\/+$/, "") || undefined;
+  overrideApiBase = url ? normalizeApiBase(url) : undefined;
 }
 
 export function getApiBase(): string {
   if (overrideApiBase) return overrideApiBase;
-  const fromEnv = process.env.TCC_BASE_URL?.replace(/\/+$/, "");
+  const fromEnv = process.env.TCC_BASE_URL
+    ? normalizeApiBase(process.env.TCC_BASE_URL)
+    : undefined;
   if (fromEnv) return fromEnv;
   return DEFAULT_API_BASE;
 }

--- a/packages/ts/liftoff/vitest.config.ts
+++ b/packages/ts/liftoff/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["src/**/*.{test,spec}.?(c|m)[jt]s?(x)"],
+  },
+});

--- a/packages/ts/otel/src/RunBatchSpanProcessor.ts
+++ b/packages/ts/otel/src/RunBatchSpanProcessor.ts
@@ -1,12 +1,12 @@
+import { Context } from "@opentelemetry/api";
 import {
   SpanProcessor,
   type ReadableSpan,
   type Span,
 } from "@opentelemetry/sdk-trace-base";
-import { getRunIdFromSpanMetadata, getSpanType } from "./utils";
-import { Context } from "@opentelemetry/api";
-import { debug } from "./internal/logger";
 import type { OTLPHttpJsonTraceExporter } from "./exporters/json/OTLPHttpJsonTraceExporter";
+import { debug } from "./internal/logger";
+import { getRunIdFromSpanMetadata, getSpanType } from "./utils";
 
 // we use the spanId of a "run" span type as the batchId
 type RunId = string;
@@ -131,13 +131,23 @@ export class RunBatchSpanProcessor implements SpanProcessor {
       this.batches.set(runId, batch);
     }
 
-    if (batch.length >= this.maxSpansPerBatch) {
-      debug(`RunBatchSpanProcessor: Dropping span for oversized batch ${runId}`);
+    const isRunSpan = getSpanType(span) === "run";
+    if (batch.length >= this.maxSpansPerBatch && !isRunSpan) {
+      debug(
+        `RunBatchSpanProcessor: Dropping span for oversized batch ${runId}`
+      );
       return;
     }
 
     if (this.queuedSpanCount >= this.maxQueuedSpans) {
       this.evictOldestBatch();
+      batch = this.batches.get(runId);
+      if (!batch) {
+        debug(
+          `RunBatchSpanProcessor: Batch ${runId} was evicted, dropping span`
+        );
+        return;
+      }
     }
 
     batch.push(span);

--- a/packages/ts/otel/src/RunBatchSpanProcessor.ts
+++ b/packages/ts/otel/src/RunBatchSpanProcessor.ts
@@ -12,6 +12,13 @@ import type { OTLPHttpJsonTraceExporter } from "./exporters/json/OTLPHttpJsonTra
 type RunId = string;
 type Batch = ReadableSpan[];
 
+type RunBatchSpanProcessorOptions = {
+  maxActiveBatches?: number;
+  maxSpansPerBatch?: number;
+  maxQueuedSpans?: number;
+  batchTimeoutMs?: number;
+};
+
 export class RunBatchSpanProcessor implements SpanProcessor {
   private shutdownOnce = { isCalled: false };
 
@@ -19,11 +26,23 @@ export class RunBatchSpanProcessor implements SpanProcessor {
 
   private batches = new Map<RunId, Batch>();
   private batchTimeouts = new Map<RunId, NodeJS.Timeout>();
+  private queuedSpanCount = 0;
 
   private exporter: OTLPHttpJsonTraceExporter;
+  private readonly maxActiveBatches: number;
+  private readonly maxSpansPerBatch: number;
+  private readonly maxQueuedSpans: number;
+  private readonly batchTimeoutMs: number;
 
-  constructor(exporter: OTLPHttpJsonTraceExporter) {
+  constructor(
+    exporter: OTLPHttpJsonTraceExporter,
+    options: RunBatchSpanProcessorOptions = {}
+  ) {
     this.exporter = exporter;
+    this.maxActiveBatches = options.maxActiveBatches ?? 1000;
+    this.maxSpansPerBatch = options.maxSpansPerBatch ?? 1000;
+    this.maxQueuedSpans = options.maxQueuedSpans ?? 10000;
+    this.batchTimeoutMs = options.batchTimeoutMs ?? 600000;
   }
 
   onStart(span: Span, _parentContext: Context): void {
@@ -105,9 +124,24 @@ export class RunBatchSpanProcessor implements SpanProcessor {
   }
 
   private addToBatch(runId: string, span: ReadableSpan) {
-    const batch = this.batches.get(runId);
-    if (batch) batch.push(span);
-    else this.batches.set(runId, [span]);
+    let batch = this.batches.get(runId);
+    if (!batch) {
+      this.evictOldestBatchesIfNeeded();
+      batch = [];
+      this.batches.set(runId, batch);
+    }
+
+    if (batch.length >= this.maxSpansPerBatch) {
+      debug(`RunBatchSpanProcessor: Dropping span for oversized batch ${runId}`);
+      return;
+    }
+
+    if (this.queuedSpanCount >= this.maxQueuedSpans) {
+      this.evictOldestBatch();
+    }
+
+    batch.push(span);
+    this.queuedSpanCount++;
 
     // reset timeout for this batch
     const existingTimeout = this.batchTimeouts.get(runId);
@@ -115,8 +149,34 @@ export class RunBatchSpanProcessor implements SpanProcessor {
 
     const timeout = setTimeout(() => {
       this.exportBatch(runId);
-    }, 600000); // 10 minutes
+    }, this.batchTimeoutMs);
     this.batchTimeouts.set(runId, timeout);
+  }
+
+  private evictOldestBatchesIfNeeded() {
+    while (this.batches.size >= this.maxActiveBatches) {
+      this.evictOldestBatch();
+    }
+  }
+
+  private evictOldestBatch() {
+    const oldestRunId = this.batches.keys().next().value as string | undefined;
+    if (!oldestRunId) return;
+
+    const batch = this.batches.get(oldestRunId);
+    const timeout = this.batchTimeouts.get(oldestRunId);
+    if (timeout) clearTimeout(timeout);
+
+    if (batch) {
+      this.queuedSpanCount = Math.max(0, this.queuedSpanCount - batch.length);
+      for (const span of batch) {
+        this.spanIdToRunId.delete(span.spanContext().spanId);
+      }
+    }
+
+    this.batches.delete(oldestRunId);
+    this.batchTimeouts.delete(oldestRunId);
+    debug(`RunBatchSpanProcessor: Dropped oldest batch ${oldestRunId}`);
   }
 
   private exportBatch(runId: string) {
@@ -131,6 +191,7 @@ export class RunBatchSpanProcessor implements SpanProcessor {
 
     this.batches.delete(runId);
     this.batchTimeouts.delete(runId);
+    this.queuedSpanCount = Math.max(0, this.queuedSpanCount - batch.length);
 
     for (const span of batch) {
       const spanId = span.spanContext().spanId;

--- a/packages/ts/otel/src/nextjs/local/global.d.ts
+++ b/packages/ts/otel/src/nextjs/local/global.d.ts
@@ -2,6 +2,7 @@ declare global {
   namespace NodeJS {
     interface Process {
       _tccWss?: WebSocketServer;
+      _tccWssToken?: string;
       _tccServer?: Server;
     }
   }

--- a/packages/ts/otel/src/nextjs/local/ws.ts
+++ b/packages/ts/otel/src/nextjs/local/ws.ts
@@ -1,4 +1,5 @@
 import net from "net";
+import crypto from "crypto";
 import { WebSocketServer } from "ws";
 import { tccLocalExporter } from "./runtime";
 import { debug } from "../../internal/logger";
@@ -6,6 +7,51 @@ import { captureAnonymousEvent } from "../telemetry/posthog";
 
 // these are completely arbitrary ports
 const PREFERRED_PORTS = [8081, 3001, 3002, 3003, 3004, 3005, 8000, 8001, 8080];
+const LOCAL_WIDGET_TOKEN =
+  process.env.TCC_LOCAL_WIDGET_TOKEN ?? crypto.randomBytes(32).toString("hex");
+
+function isAllowedOrigin(origin: string | undefined): boolean {
+  if (!origin) return true;
+  try {
+    const parsed = new URL(origin);
+    return (
+      parsed.protocol === "http:" &&
+      (parsed.hostname === "localhost" ||
+        parsed.hostname === "127.0.0.1" ||
+        parsed.hostname === "[::1]")
+    );
+  } catch {
+    return false;
+  }
+}
+
+function hasValidToken(url: string | undefined): boolean {
+  if (!url) return false;
+  try {
+    const parsed = new URL(url, "ws://127.0.0.1");
+    return parsed.searchParams.get("token") === LOCAL_WIDGET_TOKEN;
+  } catch {
+    return false;
+  }
+}
+
+function isPostHogEvent(value: unknown): value is {
+  event: string;
+  properties?: Record<string, unknown>;
+} {
+  if (!value || typeof value !== "object") return false;
+  const event = (value as { event?: unknown }).event;
+  const properties = (value as { properties?: unknown }).properties;
+  return (
+    typeof event === "string" &&
+    event.length > 0 &&
+    event.length <= 200 &&
+    (properties === undefined ||
+      (typeof properties === "object" &&
+        properties !== null &&
+        !Array.isArray(properties)))
+  );
+}
 
 async function isPortFree(port: number): Promise<boolean> {
   return new Promise((resolve) => {
@@ -13,7 +59,7 @@ async function isPortFree(port: number): Promise<boolean> {
       .createServer()
       .once("error", () => resolve(false))
       .once("listening", () => srv.close(() => resolve(true)))
-      .listen(port);
+      .listen(port, "127.0.0.1");
   });
 }
 
@@ -58,12 +104,19 @@ export const startWebSocketServer = async () => {
   }
 
   const port = await getFreePort();
-  const wss = new WebSocketServer({ port });
+  const wss = new WebSocketServer({ host: "127.0.0.1", port });
 
   process._tccWss = wss;
+  process._tccWssToken = LOCAL_WIDGET_TOKEN;
   debug(`Saved _tccWss to process`);
+  debug(`TCC local widget token: ${LOCAL_WIDGET_TOKEN}`);
 
-  wss.on("connection", (ws) => {
+  wss.on("connection", (ws, request) => {
+    if (!isAllowedOrigin(request.headers.origin) || !hasValidToken(request.url)) {
+      ws.close(1008, "Unauthorized");
+      return;
+    }
+
     debug("ws client connected");
 
     // send initial store
@@ -77,12 +130,19 @@ export const startWebSocketServer = async () => {
     ws.on("message", (data) => {
       try {
         const event = JSON.parse(data.toString());
+        if (!isPostHogEvent(event)) {
+          debug("Rejected invalid WebSocket telemetry event");
+          return;
+        }
         captureAnonymousEvent(event);
       } catch (error) {
         const errorMsg = error instanceof Error ? error.message : String(error);
         const dataStr = data.toString();
-        const truncatedData = dataStr.length > 200 ? dataStr.slice(0, 200) + "..." : dataStr;
-        debug(`Failed to parse WebSocket message: ${errorMsg}. Data: ${truncatedData}`);
+        const truncatedData =
+          dataStr.length > 200 ? dataStr.slice(0, 200) + "..." : dataStr;
+        debug(
+          `Failed to parse WebSocket message: ${errorMsg}. Data: ${truncatedData}`
+        );
       }
     });
 
@@ -104,5 +164,6 @@ export const startWebSocketServer = async () => {
   wss.on("close", () => {
     debug("wss closed");
     delete process._tccWss;
+    delete process._tccWssToken;
   });
 };

--- a/packages/ts/widget/src/auto.ts
+++ b/packages/ts/widget/src/auto.ts
@@ -1,13 +1,16 @@
 import { initWidget } from "./index";
 import { log } from "./internal/logger";
 
-async function isWebSocketServer(port: number) {
+async function isWebSocketServer(port: number, token: string) {
   return new Promise((resolve) => {
     try {
       // TODO: hide the error code for failed network requests in browser
-      const ws = new WebSocket(`ws://localhost:${port}`);
+      const ws = new WebSocket(
+        `ws://localhost:${port}?token=${encodeURIComponent(token)}`
+      );
 
       ws.addEventListener("open", () => {
+        ws.close();
         resolve(true);
       });
 
@@ -24,15 +27,29 @@ const PREFERRED_PORTS = [8081, 3001, 3002, 3003, 3004, 3005, 8000, 8001, 8080];
 
 const init = async () => {
   const debug = document.currentScript?.getAttribute("data-debug") === "true";
+  const token =
+    document.currentScript?.getAttribute("data-tcc-token") ??
+    (window as any).TCC_WSS_TOKEN;
+  const configuredPort =
+    document.currentScript?.getAttribute("data-tcc-port") ??
+    (window as any).TCC_WSS_PORT;
+
+  if (!token) {
+    throw new Error("TCC: Missing local widget token");
+  }
 
   // TODO: eliminate port scanning and use env vars for the port
   let port: string | undefined;
-  for (const p of PREFERRED_PORTS) {
-    if (await isWebSocketServer(p)) {
-      port = p.toString();
-      // window may not be defined so we use log()
-      if (debug) log(`Found TCC WebSocket server on port: ${port}`);
-      break;
+  if (configuredPort) {
+    port = configuredPort.toString();
+  } else {
+    for (const p of PREFERRED_PORTS) {
+      if (await isWebSocketServer(p, token)) {
+        port = p.toString();
+        // window may not be defined so we use log()
+        if (debug) log(`Found TCC WebSocket server on port: ${port}`);
+        break;
+      }
     }
   }
 
@@ -41,6 +58,7 @@ const init = async () => {
 
   if (typeof window !== "undefined") {
     (window as any).TCC_WSS_PORT = port;
+    (window as any).TCC_WSS_TOKEN = token;
     (window as any).TCC_DEBUG = debug;
 
     if (document.readyState === "loading") {

--- a/packages/ts/widget/src/hooks/useSyncTCCStore.ts
+++ b/packages/ts/widget/src/hooks/useSyncTCCStore.ts
@@ -36,7 +36,15 @@ const hasFailure = (items: NewItems) => {
 
 export const useSyncTCCStore = () =>
   useEffect(() => {
-    const ws = new WebSocket(`ws://localhost:${(window as any).TCC_WSS_PORT}`);
+    const token = (window as any).TCC_WSS_TOKEN;
+    if (!token) {
+      debug("Missing TCC WebSocket token");
+      return;
+    }
+
+    const ws = new WebSocket(
+      `ws://localhost:${(window as any).TCC_WSS_PORT}?token=${encodeURIComponent(token)}`
+    );
 
     ws.onopen = () => {
       debug("Connected to TCC WebSocket server");

--- a/packages/ts/widget/src/styles.css
+++ b/packages/ts/widget/src/styles.css
@@ -680,6 +680,9 @@
     -webkit-box-orient: vertical;
     -webkit-line-clamp: 2;
   }
+  .block {
+    display: block;
+  }
   .flex {
     display: flex;
   }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,6 +2,10 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
-    projects: ["packages/ts/widget/vitest.config.ts"],
+    projects: [
+      "packages/ts/api/vitest.config.ts",
+      "packages/ts/liftoff/vitest.config.ts",
+      "packages/ts/widget/vitest.config.ts",
+    ],
   },
 });


### PR DESCRIPTION
## 🎯 Changes

What changes are made in this PR? Is it a feature or a bug fix?

## ✅ Checklist

- [ ] I have followed the steps listed in the Contributing guide.
- [ ] If necessary, I have added documentation related to the changes made.
- [ ] If applicable, I have added or updated the tests related to the changes made.

## 🔒 Related Issues

Closes #

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches telemetry egress, API routing, and dev-widget auth; misconfiguration could block self-hosted setups or drop spans under load, but changes are defensive with explicit unsafe overrides.
> 
> **Overview**
> Addresses pentest findings with **secret redaction**, **API endpoint allowlisting**, **feedback validation**, **bounded OTEL batching**, and a **locked-down local dev widget**.
> 
> **Status messages** now pass through new `redactStatusMessage` / `redact_status_message` helpers in TypeScript (`@contextcompany/custom`) and Python before runs, steps, tool calls, and direct `send*` payloads ship—stripping bearer/basic auth, common `key=value` secrets, URL credentials, and known token shapes.
> 
> **Configurable TCC bases** (`TCC_BASE_URL`, `TCC_FEEDBACK_URL`, Liftoff `--api-base`) are normalized via `normalizeTCCBaseUrl` / `normalizeApiBase`: only official TCC origins or localhost unless `TCC_ALLOW_UNSAFE_BASE_URL=1`. **`submitFeedback`** rejects non-UUID `runId`s before calling the API. Vitest projects were added for `api` and `liftoff` config tests.
> 
> **`RunBatchSpanProcessor`** caps active batches, spans per batch, total queued spans, and evicts/drops under pressure to limit memory growth.
> 
> The **local widget WebSocket** binds to `127.0.0.1`, requires a per-process `token` query param (`TCC_LOCAL_WIDGET_TOKEN` or random), checks localhost origins, validates inbound PostHog-shaped events, and the widget script must supply `data-tcc-token` / `TCC_WSS_TOKEN` when connecting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae4ec6aec9c033362130773ec7bcfbe07851c053. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->