### PR TITLE
fix(python): harden pentest remediation paths

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,10 +115,12 @@ Unified Python SDK with built-in framework integrations for CrewAI, Agno, LangCh
 Each TypeScript package supports two development modes:
 
 `pnpm dev`:
+
 - **Watch mode only** - Automatically rebuilds when you save files
 - Output goes to the `dist/` folder
 
 `pnpm dev:all`:
+
 - **Watch mode + local HTTP server**
 - Automatically rebuilds AND serves the built files on port 3001 or 3002
 - Lets you use URL imports for testing your local changes outside of the workspace
@@ -173,7 +175,7 @@ We don't have a comprehensive test suite yet (contributions welcome!). For now, 
 
    ```tsx
    {
-     /* <script src="https://unpkg.com/@contextcompany/widget/dist/auto.global.js" async /> */
+     /* <script src="https://unpkg.com/@contextcompany/widget@1.0.8/dist/auto.global.js" async /> */
    }
    <script src="http://localhost:3001/auto.global.js" async />;
    ```
@@ -262,12 +264,12 @@ Now you can make changes to the widget package and see them reflected in real-ti
 3. **Add instrumentation** to your Pi session:
 
    ```typescript
-   import { createAgentSession } from '@mariozechner/pi-coding-agent';
-   import { instrumentPiSession } from '@contextcompany/pi';
+   import { instrumentPiSession } from "@contextcompany/pi";
+   import { createAgentSession } from "@mariozechner/pi-coding-agent";
 
    const { session } = await createAgentSession();
    instrumentPiSession(session, { debug: true });
-   await session.prompt('Hello');
+   await session.prompt("Hello");
    ```
 
 4. Verify debug logs show events being captured and sent.
@@ -299,13 +301,13 @@ Every commit message must follow this format: `type(scope): description`
 
 Commit messages control version bumps and changelogs automatically. CI reads your commit type to decide whether to publish a patch, minor, or major release.
 
-| Prefix | Version bump |
-|--------|-------------|
-| `fix(scope):` | patch |
-| `perf(scope):` | patch |
-| `feat(scope):` | minor |
-| `feat(scope)!:` | major |
-| `docs:` `chore:` `refactor:` `test:` `ci:` `style:` | no release |
+| Prefix                                              | Version bump |
+| --------------------------------------------------- | ------------ |
+| `fix(scope):`                                       | patch        |
+| `perf(scope):`                                      | patch        |
+| `feat(scope):`                                      | minor        |
+| `feat(scope)!:`                                     | major        |
+| `docs:` `chore:` `refactor:` `test:` `ci:` `style:` | no release   |
 
 Scopes: `otel`, `widget`, `claude`, `mastra`, `custom`, `openclaw`, `pi`, `langchain`, `api`, `python`
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 Observatory is a monorepo containing core packages for AI agent observability across TypeScript and Python:
 
 **TypeScript:**
+
 - **[@contextcompany/otel](./packages/ts/otel)** - OpenTelemetry integration for instrumenting AI SDK calls
 - **[@contextcompany/widget](./packages/ts/widget)** - Local-first UI overlay for visualizing AI agent traces in real-time
 - **[@contextcompany/claude](./packages/ts/claude)** - Instrumentation for Claude Agent SDK
@@ -16,6 +17,7 @@ Observatory is a monorepo containing core packages for AI agent observability ac
 - **[@contextcompany/api](./packages/ts/api)** - Shared API utilities (feedback, configuration)
 
 **Python:**
+
 - **[contextcompany](./packages/python)** - Python SDK with built-in integrations for LangChain, CrewAI, Agno, and LiteLLM
 
 ## Local mode (AI SDK + Next.js)
@@ -69,7 +71,8 @@ export default function RootLayout({
         {/* add The Context Company widget */}
         <Script
           crossOrigin="anonymous"
-          src="//unpkg.com/@contextcompany/widget/dist/auto.global.js"
+          integrity="sha384-ryHylpN8vggwpf+rjl5Z7CGgpVWrEAXn6WTY/Kv2RhlixzrdTMCP3/DPS3RMtNCg"
+          src="https://unpkg.com/@contextcompany/widget@1.0.8/dist/auto.global.js"
         />
         {/* other scripts */}
       </head>
@@ -100,20 +103,20 @@ const result = generateText({
 
 Check out the [examples/](./examples) directory for working demos across all supported frameworks:
 
-| Example | Framework | Language |
-|---------|-----------|----------|
-| [nextjs-widget](./examples/nextjs-widget) | AI SDK + Local Widget | TypeScript |
-| [nextjs-aisdk](./examples/nextjs-aisdk) | AI SDK + Cloud Mode | TypeScript |
-| [claude-agent-sdk](./examples/claude-agent-sdk) | Claude Agent SDK | TypeScript |
-| [langchain-ts](./examples/langchain-ts) | LangChain / LangGraph | TypeScript |
-| [mastra](./examples/mastra) | Mastra | TypeScript |
-| [custom-ts](./examples/custom-ts) | Custom Instrumentation | TypeScript |
-| [openclaw](./packages/ts/openclaw) | OpenClaw (OTLP Collector) | TypeScript |
-| [pi](./packages/ts/pi) | Pi Agent SDK | TypeScript |
-| [langchain](./examples/langchain) | LangChain | Python |
-| [crewai](./examples/crewai) | CrewAI | Python |
-| [agno](./examples/agno) | Agno | Python |
-| [custom-python](./examples/custom-python) | Custom Instrumentation | Python |
+| Example                                         | Framework                 | Language   |
+| ----------------------------------------------- | ------------------------- | ---------- |
+| [nextjs-widget](./examples/nextjs-widget)       | AI SDK + Local Widget     | TypeScript |
+| [nextjs-aisdk](./examples/nextjs-aisdk)         | AI SDK + Cloud Mode       | TypeScript |
+| [claude-agent-sdk](./examples/claude-agent-sdk) | Claude Agent SDK          | TypeScript |
+| [langchain-ts](./examples/langchain-ts)         | LangChain / LangGraph     | TypeScript |
+| [mastra](./examples/mastra)                     | Mastra                    | TypeScript |
+| [custom-ts](./examples/custom-ts)               | Custom Instrumentation    | TypeScript |
+| [openclaw](./packages/ts/openclaw)              | OpenClaw (OTLP Collector) | TypeScript |
+| [pi](./packages/ts/pi)                          | Pi Agent SDK              | TypeScript |
+| [langchain](./examples/langchain)               | LangChain                 | Python     |
+| [crewai](./examples/crewai)                     | CrewAI                    | Python     |
+| [agno](./examples/agno)                         | Agno                      | Python     |
+| [custom-python](./examples/custom-python)       | Custom Instrumentation    | Python     |
 
 ### Contributing
 

--- a/examples/nextjs-aisdk/.env.example
+++ b/examples/nextjs-aisdk/.env.example
@@ -6,3 +6,12 @@ OPENAI_API_KEY=
 # The Context Company API Key
 # Get this from your TCC dashboard
 TCC_API_KEY=
+
+# Optional protection for this example's local API routes.
+# Use matching values if you want the browser demo to call /api/chat and /api/feedback.
+TCC_EXAMPLE_API_TOKEN=
+NEXT_PUBLIC_TCC_EXAMPLE_API_TOKEN=
+
+# For throwaway local-only demos, you can bypass the example API token gate.
+# Do not set this for deployed examples.
+TCC_ALLOW_UNAUTHENTICATED_EXAMPLE_APIS=

--- a/examples/nextjs-aisdk/README.md
+++ b/examples/nextjs-aisdk/README.md
@@ -5,6 +5,7 @@ A simple example demonstrating The Context Company (TCC) telemetry integration w
 ## Overview
 
 This example shows best practices for:
+
 - Integrating TCC OpenTelemetry with Next.js and AI SDK
 - Building AI agents with tool calling
 - Implementing user feedback with runId/sessionId tracking
@@ -13,16 +14,20 @@ This example shows best practices for:
 ## Features
 
 ### Weather Assistant
+
 A minimal agent demonstrating tool calling with:
+
 - **getLocation**: Returns a random city from a list
 - **getWeather**: Returns mock weather data for a specified location
 
 ### Telemetry & Observability
+
 - Full TCC integration with runId and sessionId tracking
 - Automatic trace collection for all AI interactions
 - Tool call tracking and performance metrics
 
 ### User Feedback System
+
 - Thumbs up/down quick feedback
 - Text comments for detailed feedback
 - All feedback linked to specific AI responses via runId
@@ -30,6 +35,7 @@ A minimal agent demonstrating tool calling with:
 ## Getting Started
 
 ### Prerequisites
+
 - Node.js 18+ or compatible runtime
 - OpenAI API key
 - TCC account (optional for local development)
@@ -37,11 +43,13 @@ A minimal agent demonstrating tool calling with:
 ### Installation
 
 1. **Clone and navigate to the example:**
+
 ```bash
 cd examples/nextjs-aisdk
 ```
 
 2. **Install dependencies:**
+
 ```bash
 npm install
 # or
@@ -51,13 +59,17 @@ yarn install
 ```
 
 3. **Configure environment variables:**
+
 ```bash
 cp .env.example .env
 ```
 
 Edit `.env` and add your API keys:
+
 ```env
 OPENAI_API_KEY=your_openai_api_key_here
+TCC_EXAMPLE_API_TOKEN=choose_a_local_demo_token
+NEXT_PUBLIC_TCC_EXAMPLE_API_TOKEN=choose_a_local_demo_token
 
 # Optional for local development with TCC backend
 TCC_API_KEY=your_tcc_api_key_here
@@ -65,24 +77,29 @@ TCC_URL=http://localhost:8787/v1/traces
 TCC_FEEDBACK_URL=http://localhost:8787/v1/feedback
 ```
 
+The example API routes require the demo token above by default. For throwaway local-only testing, you can set `TCC_ALLOW_UNAUTHENTICATED_EXAMPLE_APIS=1`; do not use that setting for deployed examples.
+
 4. **Run the development server:**
+
 ```bash
 npm run dev
 ```
 
 5. **Open your browser:**
-Navigate to [http://localhost:3000](http://localhost:3000)
+   Navigate to [http://localhost:3000](http://localhost:3000)
 
 ## Usage Examples
 
 Try these prompts to see the agent in action:
 
 **Direct Weather Queries:**
+
 - "What's the weather in Tokyo?"
 - "Check the weather in San Francisco"
 - "Is it rainy in London?"
 
 **Random Location:**
+
 - "Pick a random city and tell me the weather"
 - "Surprise me with a location"
 
@@ -91,6 +108,7 @@ The agent will use the appropriate tools (getLocation and/or getWeather) to resp
 ## Architecture
 
 ### Project Structure
+
 ```
 src/
 ├── app/
@@ -109,18 +127,21 @@ src/
 ### Key Implementation Details
 
 #### TCC Instrumentation
+
 Located in `src/instrumentation.ts`:
+
 ```typescript
 import { registerOTelTCC } from "@contextcompany/otel/nextjs";
 
 export function register() {
-  if (process.env.NEXT_RUNTIME === "nodejs")
-    registerOTelTCC({ debug: true });
+  if (process.env.NEXT_RUNTIME === "nodejs") registerOTelTCC({ debug: true });
 }
 ```
 
 #### Weather Agent
+
 The weather agent is defined inline in `src/app/api/chat/route.ts` and demonstrates:
+
 - Simple tool definitions with minimal schemas
 - Mock data for 5 cities (San Francisco, New York, London, Tokyo, Sydney)
 - Ultra-minimal system prompt (1 sentence)
@@ -128,13 +149,16 @@ The weather agent is defined inline in `src/app/api/chat/route.ts` and demonstra
 - Standard AI SDK pattern with everything in one place
 
 #### Chat Endpoint
+
 `src/app/api/chat/route.ts` handles:
+
 - Request body parsing
 - Session and run ID generation
 - Agent initialization with multi-step support
 - TCC metadata attachment
 
 #### Feedback Flow
+
 1. User clicks thumbs up/down or comment button
 2. Frontend sends feedback with runId to `/api/feedback`
 3. Backend validates and submits to TCC via `submitFeedback()`
@@ -157,6 +181,7 @@ After running the application and generating some conversations:
 The agent uses `maxSteps: 5` to enable multi-step workflows. For example:
 
 **User:** "Pick a random city and tell me the weather"
+
 1. **Step 1**: Agent calls `getLocation()` → returns "London"
 2. **Step 2**: Agent calls `getWeather("London")` → returns weather data
 3. **Step 3**: Agent generates response with the weather information
@@ -171,7 +196,7 @@ To modify the weather locations, edit the constants at the top of `src/app/api/c
 const locations = ["Your", "Custom", "Cities"];
 
 const mockWeather: Record<string, any> = {
-  "Your": { temp: 70, condition: "Sunny", humidity: 50 },
+  Your: { temp: 70, condition: "Sunny", humidity: 50 },
   // Add more cities...
 };
 ```
@@ -179,17 +204,20 @@ const mockWeather: Record<string, any> = {
 ## Troubleshooting
 
 **Issue:** No traces appearing in TCC dashboard
+
 - Verify `instrumentation.ts` is in `src/` directory
 - Check environment variables are set correctly
 - Ensure `experimental_telemetry.isEnabled` is `true`
 - Look for errors in server console
 
 **Issue:** Feedback not submitting
+
 - Verify runId is being passed correctly from chat route
 - Check network tab for API errors
 - Confirm TCC_FEEDBACK_URL is correct
 
 **Issue:** Agent stops after one tool call
+
 - Verify `maxSteps: 5` is set in the agent configuration
 - Check server logs for errors
 

--- a/examples/nextjs-aisdk/src/app/api/_example-auth.ts
+++ b/examples/nextjs-aisdk/src/app/api/_example-auth.ts
@@ -1,3 +1,4 @@
+import { timingSafeEqual } from "crypto";
 import { NextResponse } from "next/server";
 
 const EXAMPLE_TOKEN_HEADER = "x-tcc-example-token";
@@ -18,9 +19,19 @@ export function authorizeExampleRequest(request: Request): NextResponse | null {
     );
   }
 
-  if (request.headers.get(EXAMPLE_TOKEN_HEADER) !== expectedToken) {
+  if (!tokensEqual(request.headers.get(EXAMPLE_TOKEN_HEADER), expectedToken)) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
   return null;
+}
+
+function tokensEqual(provided: string | null, expected: string): boolean {
+  const providedBuffer = Buffer.from(provided ?? "");
+  const expectedBuffer = Buffer.from(expected);
+
+  return (
+    providedBuffer.length === expectedBuffer.length &&
+    timingSafeEqual(providedBuffer, expectedBuffer)
+  );
 }

--- a/examples/nextjs-aisdk/src/app/api/_example-auth.ts
+++ b/examples/nextjs-aisdk/src/app/api/_example-auth.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from "next/server";
+
+const EXAMPLE_TOKEN_HEADER = "x-tcc-example-token";
+
+export function authorizeExampleRequest(request: Request): NextResponse | null {
+  if (process.env.TCC_ALLOW_UNAUTHENTICATED_EXAMPLE_APIS === "1") {
+    return null;
+  }
+
+  const expectedToken = process.env.TCC_EXAMPLE_API_TOKEN;
+  if (!expectedToken) {
+    return NextResponse.json(
+      {
+        error:
+          "Example API routes are disabled. Set TCC_EXAMPLE_API_TOKEN or TCC_ALLOW_UNAUTHENTICATED_EXAMPLE_APIS=1 for local-only demos.",
+      },
+      { status: 403 }
+    );
+  }
+
+  if (request.headers.get(EXAMPLE_TOKEN_HEADER) !== expectedToken) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  return null;
+}

--- a/examples/nextjs-aisdk/src/app/api/chat/route.ts
+++ b/examples/nextjs-aisdk/src/app/api/chat/route.ts
@@ -1,11 +1,15 @@
-import { openai } from "@ai-sdk/openai";
-import { convertToModelMessages, streamText, stepCountIs } from "ai";
 import { randomUUID } from "crypto";
+import { openai } from "@ai-sdk/openai";
+import { convertToModelMessages, stepCountIs, streamText } from "ai";
+import { authorizeExampleRequest } from "../_example-auth";
 import { weatherTools } from "./agent";
 
 export const maxDuration = 60;
 
 export async function POST(req: Request) {
+  const unauthorized = authorizeExampleRequest(req);
+  if (unauthorized) return unauthorized;
+
   const body = await req.json();
   const { messages } = body;
 

--- a/examples/nextjs-aisdk/src/app/api/feedback/route.ts
+++ b/examples/nextjs-aisdk/src/app/api/feedback/route.ts
@@ -1,7 +1,11 @@
-import { submitFeedback } from "@contextcompany/otel";
 import { NextRequest, NextResponse } from "next/server";
+import { submitFeedback } from "@contextcompany/otel";
+import { authorizeExampleRequest } from "../_example-auth";
 
 export async function POST(request: NextRequest) {
+  const unauthorized = authorizeExampleRequest(request);
+  if (unauthorized) return unauthorized;
+
   try {
     const body = await request.json();
     const { runId, score, comment } = body;

--- a/examples/nextjs-aisdk/src/app/page.tsx
+++ b/examples/nextjs-aisdk/src/app/page.tsx
@@ -1,10 +1,12 @@
 "use client";
 
+import { useMemo, useState } from "react";
 import { useChat } from "@ai-sdk/react";
-import { useState } from "react";
+import { DefaultChatTransport } from "ai";
 import { FeedbackButtons } from "@/components/feedback-buttons";
 
 const generateSessionId = () => Math.random().toString(36).substring(2, 15);
+const exampleApiToken = process.env.NEXT_PUBLIC_TCC_EXAMPLE_API_TOKEN;
 
 interface MessageMetadata {
   runId?: string;
@@ -16,17 +18,28 @@ export default function Chat() {
   // TCC: Generate sessionId to track this conversation across multiple requests
   const [sessionId] = useState<string>(generateSessionId());
 
-  const { messages, sendMessage } = useChat();
+  const transport = useMemo(
+    () =>
+      new DefaultChatTransport({
+        headers: exampleApiToken
+          ? { "x-tcc-example-token": exampleApiToken }
+          : undefined,
+      }),
+    []
+  );
+
+  const { messages, sendMessage } = useChat({ transport });
 
   return (
-    <div className="flex flex-col w-full max-w-md py-24 mx-auto stretch">
+    <div className="stretch mx-auto flex w-full max-w-md flex-col py-24">
       <div className="mb-4 text-sm text-zinc-500 dark:text-zinc-400">
-        Weather Assistant - Try: &quot;What&apos;s the weather in Tokyo?&quot; or &quot;Pick a random city&quot;
+        Weather Assistant - Try: &quot;What&apos;s the weather in Tokyo?&quot;
+        or &quot;Pick a random city&quot;
       </div>
 
       {messages.map((message) => (
-        <div key={message.id} className="whitespace-pre-wrap mb-4">
-          <div className="font-semibold text-zinc-700 dark:text-zinc-300 mb-1">
+        <div key={message.id} className="mb-4 whitespace-pre-wrap">
+          <div className="mb-1 font-semibold text-zinc-700 dark:text-zinc-300">
             {message.role === "user" ? "You:" : "Assistant:"}
           </div>
           <div className="text-zinc-900 dark:text-zinc-100">
@@ -64,7 +77,7 @@ export default function Chat() {
         }}
       >
         <input
-          className="fixed dark:bg-zinc-900 bottom-0 w-full max-w-md p-2 mb-8 border border-zinc-300 dark:border-zinc-800 rounded shadow-xl focus:outline-none focus:ring-2 focus:ring-blue-500"
+          className="fixed bottom-0 mb-8 w-full max-w-md rounded border border-zinc-300 p-2 shadow-xl focus:ring-2 focus:ring-blue-500 focus:outline-none dark:border-zinc-800 dark:bg-zinc-900"
           value={input}
           placeholder="Type your message..."
           onChange={(e) => setInput(e.currentTarget.value)}

--- a/examples/nextjs-aisdk/src/components/feedback-buttons.tsx
+++ b/examples/nextjs-aisdk/src/components/feedback-buttons.tsx
@@ -2,6 +2,8 @@
 
 import { useState } from "react";
 
+const exampleApiToken = process.env.NEXT_PUBLIC_TCC_EXAMPLE_API_TOKEN;
+
 type FeedbackButtonsProps = {
   runId: string; // TCC: Unique ID linking feedback to specific AI response
 };
@@ -27,6 +29,9 @@ export function FeedbackButtons({ runId }: FeedbackButtonsProps) {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
+          ...(exampleApiToken
+            ? { "x-tcc-example-token": exampleApiToken }
+            : {}),
         },
         body: JSON.stringify({ runId, score }),
       });
@@ -53,6 +58,9 @@ export function FeedbackButtons({ runId }: FeedbackButtonsProps) {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
+          ...(exampleApiToken
+            ? { "x-tcc-example-token": exampleApiToken }
+            : {}),
         },
         body: JSON.stringify({
           runId, // TCC: Links comment to specific AI response
@@ -76,15 +84,15 @@ export function FeedbackButtons({ runId }: FeedbackButtonsProps) {
 
   return (
     <>
-      <div className="flex items-center gap-2 mt-2">
+      <div className="mt-2 flex items-center gap-2">
         <button
           onClick={() => handleFeedback("thumbs_up")}
           disabled={isSubmitting}
-          className={`p-1.5 rounded-md transition-colors ${
+          className={`rounded-md p-1.5 transition-colors ${
             selectedScore === "thumbs_up"
-              ? "bg-green-100 dark:bg-green-900 text-green-700 dark:text-green-300"
-              : "hover:bg-zinc-100 dark:hover:bg-zinc-800 text-zinc-500 dark:text-zinc-400"
-          } disabled:opacity-50 disabled:cursor-not-allowed`}
+              ? "bg-green-100 text-green-700 dark:bg-green-900 dark:text-green-300"
+              : "text-zinc-500 hover:bg-zinc-100 dark:text-zinc-400 dark:hover:bg-zinc-800"
+          } disabled:cursor-not-allowed disabled:opacity-50`}
           aria-label="Thumbs up"
           title="Good response"
         >
@@ -93,11 +101,11 @@ export function FeedbackButtons({ runId }: FeedbackButtonsProps) {
         <button
           onClick={() => handleFeedback("thumbs_down")}
           disabled={isSubmitting}
-          className={`p-1.5 rounded-md transition-colors ${
+          className={`rounded-md p-1.5 transition-colors ${
             selectedScore === "thumbs_down"
-              ? "bg-red-100 dark:bg-red-900 text-red-700 dark:text-red-300"
-              : "hover:bg-zinc-100 dark:hover:bg-zinc-800 text-zinc-500 dark:text-zinc-400"
-          } disabled:opacity-50 disabled:cursor-not-allowed`}
+              ? "bg-red-100 text-red-700 dark:bg-red-900 dark:text-red-300"
+              : "text-zinc-500 hover:bg-zinc-100 dark:text-zinc-400 dark:hover:bg-zinc-800"
+          } disabled:cursor-not-allowed disabled:opacity-50`}
           aria-label="Thumbs down"
           title="Bad response"
         >
@@ -105,7 +113,7 @@ export function FeedbackButtons({ runId }: FeedbackButtonsProps) {
         </button>
         <button
           onClick={() => setShowCommentModal(true)}
-          className="p-1.5 px-3 rounded-md transition-colors hover:bg-zinc-100 dark:hover:bg-zinc-800 text-zinc-600 dark:text-zinc-400 text-sm"
+          className="rounded-md p-1.5 px-3 text-sm text-zinc-600 transition-colors hover:bg-zinc-100 dark:text-zinc-400 dark:hover:bg-zinc-800"
           title="Add comment"
         >
           💬 Comment
@@ -113,23 +121,23 @@ export function FeedbackButtons({ runId }: FeedbackButtonsProps) {
       </div>
 
       {showCommentModal && (
-        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
-          <div className="bg-white dark:bg-zinc-900 p-6 rounded-lg shadow-xl max-w-md w-full mx-4">
-            <h3 className="text-lg font-semibold mb-4 text-zinc-900 dark:text-zinc-100">
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+          <div className="mx-4 w-full max-w-md rounded-lg bg-white p-6 shadow-xl dark:bg-zinc-900">
+            <h3 className="mb-4 text-lg font-semibold text-zinc-900 dark:text-zinc-100">
               Add Feedback Comment
             </h3>
             <textarea
               value={comment}
               onChange={(e) => setComment(e.target.value)}
               placeholder="Share your thoughts about this response..."
-              className="w-full p-3 border border-zinc-300 dark:border-zinc-700 rounded-md bg-white dark:bg-zinc-800 text-zinc-900 dark:text-zinc-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
+              className="w-full rounded-md border border-zinc-300 bg-white p-3 text-zinc-900 focus:ring-2 focus:ring-blue-500 focus:outline-none dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100"
               rows={4}
             />
-            <div className="flex gap-2 mt-4">
+            <div className="mt-4 flex gap-2">
               <button
                 onClick={handleCommentSubmit}
                 disabled={!comment.trim() || isSubmittingComment}
-                className="flex-1 px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                className="flex-1 rounded-md bg-blue-600 px-4 py-2 text-white transition-colors hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
               >
                 {isSubmittingComment ? "Submitting..." : "Submit"}
               </button>
@@ -138,7 +146,7 @@ export function FeedbackButtons({ runId }: FeedbackButtonsProps) {
                   setShowCommentModal(false);
                   setComment("");
                 }}
-                className="flex-1 px-4 py-2 bg-zinc-200 dark:bg-zinc-700 text-zinc-900 dark:text-zinc-100 rounded-md hover:bg-zinc-300 dark:hover:bg-zinc-600 transition-colors"
+                className="flex-1 rounded-md bg-zinc-200 px-4 py-2 text-zinc-900 transition-colors hover:bg-zinc-300 dark:bg-zinc-700 dark:text-zinc-100 dark:hover:bg-zinc-600"
               >
                 Cancel
               </button>

--- a/examples/nextjs-widget/README.md
+++ b/examples/nextjs-widget/README.md
@@ -124,7 +124,11 @@ Located in `app/layout.tsx:30-32`:
 
 ```typescript
 {process.env.NODE_ENV === "development" && (
-  <Script src="https://unpkg.com/@contextcompany/widget/dist/auto.global.js" />
+  <Script
+    crossOrigin="anonymous"
+    integrity="sha384-ryHylpN8vggwpf+rjl5Z7CGgpVWrEAXn6WTY/Kv2RhlixzrdTMCP3/DPS3RMtNCg"
+    src="https://unpkg.com/@contextcompany/widget@1.0.8/dist/auto.global.js"
+  />
 )}
 ```
 

--- a/examples/nextjs-widget/app/layout.tsx
+++ b/examples/nextjs-widget/app/layout.tsx
@@ -28,7 +28,11 @@ export default function RootLayout({
       <head>
         {/* add The Context Company widget when running locally */}
         {process.env.NODE_ENV === "development" && (
-          <Script src="https://unpkg.com/@contextcompany/widget/dist/auto.global.js" />
+          <Script
+            crossOrigin="anonymous"
+            integrity="sha384-ryHylpN8vggwpf+rjl5Z7CGgpVWrEAXn6WTY/Kv2RhlixzrdTMCP3/DPS3RMtNCg"
+            src="https://unpkg.com/@contextcompany/widget@1.0.8/dist/auto.global.js"
+          />
         )}
       </head>
       <body

--- a/packages/python/contextcompany/config.py
+++ b/packages/python/contextcompany/config.py
@@ -1,8 +1,10 @@
 import os
 from typing import Optional
+from urllib.parse import urlparse
 
 PROD_BASE = "https://api.thecontext.company"
 DEV_BASE = "https://dev.thecontext.company"
+ALLOWED_REMOTE_ORIGINS = {PROD_BASE, DEV_BASE}
 
 
 def get_api_key(api_key: Optional[str] = None) -> str:
@@ -18,10 +20,41 @@ def get_api_key(api_key: Optional[str] = None) -> str:
 def get_base_url(api_key: Optional[str] = None) -> str:
     url = os.getenv("TCC_BASE_URL")
     if url:
-        return url.rstrip("/")
+        return normalize_base_url(url)
     key = api_key or os.getenv("TCC_API_KEY", "")
     return DEV_BASE if key.startswith("dev_") else PROD_BASE
 
 
 def get_url(path: str, api_key: Optional[str] = None) -> str:
     return f"{get_base_url(api_key)}{path}"
+
+
+def _is_unsafe_base_url_allowed() -> bool:
+    return os.getenv("TCC_ALLOW_UNSAFE_BASE_URL") == "1"
+
+
+def _is_localhost_host(hostname: str) -> bool:
+    return hostname.lower() in {"localhost", "127.0.0.1", "::1"}
+
+
+def normalize_base_url(url: str) -> str:
+    parsed = urlparse(url)
+    if parsed.scheme not in {"http", "https"} or not parsed.hostname:
+        raise ValueError(f"[TCC] Invalid TCC base URL: {url}")
+
+    hostname = parsed.hostname.lower()
+    host = f"[{hostname}]" if ":" in hostname and not hostname.startswith("[") else hostname
+    port = f":{parsed.port}" if parsed.port else ""
+    origin = f"{parsed.scheme.lower()}://{host}{port}"
+    base = f"{origin}{parsed.path.rstrip('/')}"
+
+    if origin in ALLOWED_REMOTE_ORIGINS or _is_localhost_host(hostname):
+        return base
+
+    if _is_unsafe_base_url_allowed():
+        return base
+
+    raise ValueError(
+        f"[TCC] Refusing unsafe TCC base URL ({base}). Use {PROD_BASE}, {DEV_BASE}, "
+        "localhost, or set TCC_ALLOW_UNSAFE_BASE_URL=1 for self-hosted testing."
+    )

--- a/packages/python/contextcompany/config.py
+++ b/packages/python/contextcompany/config.py
@@ -44,7 +44,10 @@ def normalize_base_url(url: str) -> str:
 
     hostname = parsed.hostname.lower()
     host = f"[{hostname}]" if ":" in hostname and not hostname.startswith("[") else hostname
-    port = f":{parsed.port}" if parsed.port else ""
+    is_default_port = (parsed.scheme == "https" and parsed.port == 443) or (
+        parsed.scheme == "http" and parsed.port == 80
+    )
+    port = f":{parsed.port}" if parsed.port and not is_default_port else ""
     origin = f"{parsed.scheme.lower()}://{host}{port}"
     base = f"{origin}{parsed.path.rstrip('/')}"
 

--- a/packages/python/tests/test_config.py
+++ b/packages/python/tests/test_config.py
@@ -17,11 +17,19 @@ class NormalizeBaseUrlTests(unittest.TestCase):
             normalize_base_url("https://dev.thecontext.company/v1"),
             "https://dev.thecontext.company/v1",
         )
+        self.assertEqual(
+            normalize_base_url("https://api.thecontext.company:443/v1"),
+            "https://api.thecontext.company/v1",
+        )
 
     def test_allows_localhost(self):
         self.assertEqual(
             normalize_base_url("http://localhost:8787/"),
             "http://localhost:8787",
+        )
+        self.assertEqual(
+            normalize_base_url("http://localhost:80/"),
+            "http://localhost",
         )
 
     def test_rejects_arbitrary_remote_origins_unless_allowed(self):

--- a/packages/python/tests/test_config.py
+++ b/packages/python/tests/test_config.py
@@ -1,0 +1,35 @@
+import os
+import unittest
+
+from contextcompany.config import normalize_base_url
+
+
+class NormalizeBaseUrlTests(unittest.TestCase):
+    def tearDown(self):
+        os.environ.pop("TCC_ALLOW_UNSAFE_BASE_URL", None)
+
+    def test_allows_official_origins(self):
+        self.assertEqual(
+            normalize_base_url("https://api.thecontext.company/"),
+            "https://api.thecontext.company",
+        )
+        self.assertEqual(
+            normalize_base_url("https://dev.thecontext.company/v1"),
+            "https://dev.thecontext.company/v1",
+        )
+
+    def test_allows_localhost(self):
+        self.assertEqual(
+            normalize_base_url("http://localhost:8787/"),
+            "http://localhost:8787",
+        )
+
+    def test_rejects_arbitrary_remote_origins_unless_allowed(self):
+        with self.assertRaisesRegex(ValueError, "Refusing unsafe"):
+            normalize_base_url("https://evil.example")
+
+        os.environ["TCC_ALLOW_UNSAFE_BASE_URL"] = "1"
+        self.assertEqual(
+            normalize_base_url("https://self-hosted.example/"),
+            "https://self-hosted.example",
+        )


### PR DESCRIPTION
## 🎯 Changes

What changes are made in this PR? Is it a feature or a bug fix?

## ✅ Checklist

- [ ] I have followed the steps listed in the Contributing guide.
- [ ] If necessary, I have added documentation related to the changes made.
- [ ] If applicable, I have added or updated the tests related to the changes made.

## 🔒 Related Issues

Closes #

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Python URL validation can break deployments that relied on arbitrary `TCC_BASE_URL` without the new opt-in flag; example APIs are locked down by default, which changes local setup expectations.
> 
> **Overview**
> **Pentest-style hardening** across the Python SDK, the cloud-mode Next.js example, and widget install docs.
> 
> The Python SDK now **normalizes and validates** `TCC_BASE_URL` via `normalize_base_url()`: only official TCC hosts, localhost, or (with `TCC_ALLOW_UNSAFE_BASE_URL=1`) self-hosted origins are accepted; other remote URLs raise. Unit tests cover allow/deny behavior.
> 
> The **nextjs-aisdk** example protects `/api/chat` and `/api/feedback` with a shared **`x-tcc-example-token`** (timing-safe compare), env-driven server/client tokens, optional **`TCC_ALLOW_UNAUTHENTICATED_EXAMPLE_APIS=1`** for local-only demos, and updated `.env.example` / README.
> 
> **Widget loading** in README, `nextjs-widget`, and CONTRIBUTING is pinned to **`@contextcompany/widget@1.0.8`** with **SRI** and `crossOrigin="anonymous"` on the unpkg script.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 970c51e19c277383da88178874d403291bdc8dc3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->