### PR TITLE
fix(examples): stop loading widget/otel from unpkg CDN by default (TCC-167)

### DIFF
--- a/examples/nextjs-widget/README.md
+++ b/examples/nextjs-widget/README.md
@@ -120,7 +120,14 @@ examples/nextjs-widget/
 
 #### Widget Integration
 
-Located in `app/layout.tsx:30-32`:
+The widget is **not loaded by default**. `app/layout.tsx` ships without the
+script so the example never pulls third-party JavaScript from a CDN at runtime
+(avoiding supply-chain / MITM risk). The file contains a comment with the exact
+snippet to enable it.
+
+To add the widget, put `import Script from "next/script"` at the top of
+`app/layout.tsx` and render it in `<head>` (dev only), pinned to an exact
+version with a Subresource Integrity hash:
 
 ```typescript
 {process.env.NODE_ENV === "development" && (
@@ -132,7 +139,7 @@ Located in `app/layout.tsx:30-32`:
 )}
 ```
 
-This conditionally loads the widget only in development mode, keeping your production bundle clean.
+The `process.env.NODE_ENV === "development"` guard keeps the widget out of production builds. Regenerate the integrity hash with `curl -fsSL <url> | openssl dgst -sha384 -binary | openssl base64 -A` whenever you change the version.
 
 #### Local Mode Telemetry
 

--- a/examples/nextjs-widget/app/layout.tsx
+++ b/examples/nextjs-widget/app/layout.tsx
@@ -26,7 +26,16 @@ export default function RootLayout({
   return (
     <html lang="en">
       <head>
-        {/* add The Context Company widget when running locally */}
+        {/*
+          Add The Context Company widget when running locally.
+
+          The script is pinned to an exact version and guarded with a
+          Subresource Integrity (SRI) hash + crossOrigin so a compromised or
+          MITM'd CDN response cannot inject arbitrary JavaScript. When bumping
+          the version, regenerate the integrity hash and update both together:
+            curl -fsSL https://unpkg.com/@contextcompany/widget@<version>/dist/auto.global.js \
+              | openssl dgst -sha384 -binary | openssl base64 -A
+        */}
         {process.env.NODE_ENV === "development" && (
           <Script
             crossOrigin="anonymous"

--- a/examples/nextjs-widget/app/layout.tsx
+++ b/examples/nextjs-widget/app/layout.tsx
@@ -1,7 +1,6 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
-import Script from "next/script";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -27,22 +26,27 @@ export default function RootLayout({
     <html lang="en">
       <head>
         {/*
-          Add The Context Company widget when running locally.
+          The Context Company widget is intentionally NOT loaded here. This
+          example pulls no third-party JavaScript from a CDN at runtime, which
+          avoids the supply-chain / MITM risk of remote scripts entirely.
 
-          The script is pinned to an exact version and guarded with a
-          Subresource Integrity (SRI) hash + crossOrigin so a compromised or
-          MITM'd CDN response cannot inject arbitrary JavaScript. When bumping
-          the version, regenerate the integrity hash and update both together:
+          If you want the widget, add `import Script from "next/script"` at the
+          top of this file and render it below (dev only). Pin an exact version
+          and add a Subresource Integrity hash + crossOrigin so a compromised or
+          MITM'd CDN response cannot inject arbitrary JavaScript:
+
+            {process.env.NODE_ENV === "development" && (
+              <Script
+                crossOrigin="anonymous"
+                integrity="sha384-ryHylpN8vggwpf+rjl5Z7CGgpVWrEAXn6WTY/Kv2RhlixzrdTMCP3/DPS3RMtNCg"
+                src="https://unpkg.com/@contextcompany/widget@1.0.8/dist/auto.global.js"
+              />
+            )}
+
+          Regenerate the integrity hash whenever you change the version:
             curl -fsSL https://unpkg.com/@contextcompany/widget@<version>/dist/auto.global.js \
               | openssl dgst -sha384 -binary | openssl base64 -A
         */}
-        {process.env.NODE_ENV === "development" && (
-          <Script
-            crossOrigin="anonymous"
-            integrity="sha384-ryHylpN8vggwpf+rjl5Z7CGgpVWrEAXn6WTY/Kv2RhlixzrdTMCP3/DPS3RMtNCg"
-            src="https://unpkg.com/@contextcompany/widget@1.0.8/dist/auto.global.js"
-          />
-        )}
       </head>
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}

--- a/examples/nextjs-widget/next.config.ts
+++ b/examples/nextjs-widget/next.config.ts
@@ -2,12 +2,6 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   /* config options here */
-  experimental: {
-    urlImports: [
-      "http://localhost:3002/nextjs/local/auto.global.js",
-      "https://unpkg.com/@contextcompany/otel/dist/nextjs/local/auto.global.js",
-    ],
-  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 🎯 Changes

Bug fix / security hardening for Oneleet pentest finding **TC-007** (Linear **TCC-167**): the `nextjs-widget` example loaded code from the unpkg CDN, creating a supply-chain / MITM risk where a compromised CDN, npm publish hijack, or MITM could inject arbitrary JavaScript.

Rather than just hardening the CDN reference, this example now pulls **zero** third-party JavaScript from a CDN at runtime:

- **`app/layout.tsx`** — removed the widget `<Script>` tag entirely (and the now-unused `next/script` import). In its place is a comment with a ready-to-paste snippet (exact version pin + Subresource Integrity hash + `crossOrigin`, dev-only) plus the command to regenerate the SRI hash, so anyone who *wants* the widget can opt in securely.
- **`next.config.ts`** — removed `experimental.urlImports`, which referenced an **unpinned** `https://unpkg.com/@contextcompany/otel/.../auto.global.js`. This was dead config: otel is loaded from the workspace package in `instrumentation.ts`, and nothing imported from the URL.
- **`examples/nextjs-widget/README.md`** — updated the "Widget Integration" section to document that the widget is opt-in by default and how to enable it securely.

### Verification

- Confirmed the SRI hash in the documented snippet is **correct** for `@contextcompany/widget@1.0.8` (recomputed `sha384` of the unpkg file — exact match).
- Audited all remaining `unpkg.com` references: none are loaded by the example at runtime anymore; docs/snippets are version-pinned; `.changeset/config.json` is a pinned tooling JSON-schema URL (not browser-executed).
- `pnpm build` (Next.js production build + TypeScript check) ✅
- `pnpm lint` ✅ (0 errors; pre-existing unrelated warnings in `proxy.ts`)
- `prettier --check` on edited files ✅

No published-package code changed (the example is private and changeset-ignored), so no release is triggered.

## ✅ Checklist

- [x] I have followed the steps listed in the Contributing guide.
- [x] If necessary, I have added documentation related to the changes made.
- [ ] If applicable, I have added or updated the tests related to the changes made. (No test suite exists for the example app; verified via build/lint.)

## 🔒 Related Issues

Resolves TCC-167 (Oneleet pentest finding TC-007).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bdaf5ab8-c6ff-44ad-b906-ea0c2d6c8724"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bdaf5ab8-c6ff-44ad-b906-ea0c2d6c8724"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

