### PR TITLE
fix: block API key/telemetry exfiltration via endpoint hijacking (TC-006)

### DIFF
--- a/.changeset/secure-telemetry-sink-urls.md
+++ b/.changeset/secure-telemetry-sink-urls.md
@@ -1,0 +1,19 @@
+---
+"@contextcompany/api": patch
+"@contextcompany/custom": patch
+"@contextcompany/otel": patch
+"@contextcompany/claude": patch
+"@contextcompany/pi": patch
+"@contextcompany/mastra": patch
+"@contextcompany/langchain": patch
+"@contextcompany/openclaw": patch
+---
+
+fix: refuse to send the API key or telemetry to non-TCC endpoints (TC-006)
+
+Adds a shared `assertSafeTCCUrl` guard in `@contextcompany/api` and enforces it
+at every network sink that attaches `Authorization: Bearer <TCC_API_KEY>` (OTLP
+trace exporter, custom/claude/pi/mastra/langchain/openclaw transports). The
+guard rejects any origin that isn't TCC-controlled (prod/dev/localhost) unless
+`TCC_ALLOW_UNSAFE_BASE_URL=1` is set, so a hijacked `TCC_BASE_URL` or an
+explicit endpoint override can no longer exfiltrate the API key or trace data.

--- a/packages/python/contextcompany/_utils.py
+++ b/packages/python/contextcompany/_utils.py
@@ -31,7 +31,7 @@ def _send_payload(
     api_key: Optional[str] = None,
     tcc_url: Optional[str] = None,
 ) -> None:
-    from .config import get_api_key, get_url
+    from .config import assert_safe_url, get_api_key, get_url
 
     _debug(f"Sending {label}...")
     _debug("Payload:", payload)
@@ -39,6 +39,8 @@ def _send_payload(
     try:
         api_key = get_api_key(api_key)
         endpoint = tcc_url or get_url("/v1/custom", api_key=api_key)
+        # Never attach the API key / send payloads to a non-TCC origin.
+        assert_safe_url(endpoint)
 
         resp = requests.post(
             endpoint,

--- a/packages/python/contextcompany/agno/__init__.py
+++ b/packages/python/contextcompany/agno/__init__.py
@@ -24,7 +24,7 @@ from opentelemetry.sdk.resources import Resource
 from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
 
 from ..otel import RunIdSpanProcessor, TraceBatchSpanProcessor
-from ..config import get_api_key, get_url
+from ..config import assert_safe_url, get_api_key, get_url
 from .._utils import _debug
 from .exporter import MetadataFixingExporter
 
@@ -60,6 +60,8 @@ def instrument_agno(
 
     resolved_api_key = get_api_key(api_key)
     resolved_endpoint = tcc_url or get_url("/v1/traces", api_key=resolved_api_key)
+    # Never attach the API key / send telemetry to a non-TCC origin.
+    assert_safe_url(resolved_endpoint)
 
     _debug("Initializing Agno instrumentation")
     _debug(f"Endpoint: {resolved_endpoint}")

--- a/packages/python/contextcompany/claude/claude.py
+++ b/packages/python/contextcompany/claude/claude.py
@@ -45,7 +45,7 @@ from typing import Any, AsyncIterator, Dict, List, Optional
 
 import requests
 
-from ..config import get_api_key, get_url
+from ..config import assert_safe_url, get_api_key, get_url
 
 
 # Per-call debug scope.  Using a ContextVar (not ``os.environ``) so concurrent
@@ -326,6 +326,8 @@ def _send_to_tcc(
     try:
         resolved_key = get_api_key(api_key)
         endpoint = tcc_url or get_url("/v1/claude", api_key=resolved_key)
+        # Never attach the API key / send telemetry to a non-TCC origin.
+        assert_safe_url(endpoint)
         resp = requests.post(
             endpoint,
             json=payload,

--- a/packages/python/contextcompany/config.py
+++ b/packages/python/contextcompany/config.py
@@ -37,10 +37,11 @@ def _is_localhost_host(hostname: str) -> bool:
     return hostname.lower() in {"localhost", "127.0.0.1", "::1"}
 
 
-def normalize_base_url(url: str) -> str:
+def _split_origin(url: str, label: str) -> tuple[str, str, str]:
+    """Parse `url` into ``(origin, hostname, path)``; raise on malformed input."""
     parsed = urlparse(url)
     if parsed.scheme not in {"http", "https"} or not parsed.hostname:
-        raise ValueError(f"[TCC] Invalid TCC base URL: {url}")
+        raise ValueError(f"[TCC] Invalid {label}: {url}")
 
     hostname = parsed.hostname.lower()
     host = f"[{hostname}]" if ":" in hostname and not hostname.startswith("[") else hostname
@@ -49,15 +50,48 @@ def normalize_base_url(url: str) -> str:
     )
     port = f":{parsed.port}" if parsed.port and not is_default_port else ""
     origin = f"{parsed.scheme.lower()}://{host}{port}"
-    base = f"{origin}{parsed.path.rstrip('/')}"
+    return origin, hostname, parsed.path
 
-    if origin in ALLOWED_REMOTE_ORIGINS or _is_localhost_host(hostname):
-        return base
 
-    if _is_unsafe_base_url_allowed():
+def _is_origin_allowed(origin: str, hostname: str) -> bool:
+    """Whether the SDK may send the API key / telemetry to this origin."""
+    return (
+        origin in ALLOWED_REMOTE_ORIGINS
+        or _is_localhost_host(hostname)
+        or _is_unsafe_base_url_allowed()
+    )
+
+
+def normalize_base_url(url: str) -> str:
+    origin, hostname, path = _split_origin(url, "TCC base URL")
+    base = f"{origin}{path.rstrip('/')}"
+
+    if _is_origin_allowed(origin, hostname):
         return base
 
     raise ValueError(
         f"[TCC] Refusing unsafe TCC base URL ({base}). Use {PROD_BASE}, {DEV_BASE}, "
         "localhost, or set TCC_ALLOW_UNSAFE_BASE_URL=1 for self-hosted testing."
+    )
+
+
+def assert_safe_url(url: str) -> str:
+    """Defense-in-depth guard for network sinks that attach the TCC API key.
+
+    Returns `url` unchanged when it targets an allowed TCC origin
+    (prod/dev/localhost) or ``TCC_ALLOW_UNSAFE_BASE_URL=1`` is set; otherwise
+    raises ``ValueError``. Complements :func:`normalize_base_url`: even if an
+    endpoint reaches a sink without base-URL normalization (e.g. an explicit
+    ``tcc_url`` override or a hijacked ``TCC_FEEDBACK_URL``), the API key and
+    trace data are never sent to an untrusted host.
+    """
+    origin, hostname, _path = _split_origin(url, "TCC URL")
+
+    if _is_origin_allowed(origin, hostname):
+        return url
+
+    raise ValueError(
+        f"[TCC] Refusing to send credentials to unsafe URL ({origin}). Use "
+        f"{PROD_BASE}, {DEV_BASE}, localhost, or set TCC_ALLOW_UNSAFE_BASE_URL=1 "
+        "for self-hosted testing."
     )

--- a/packages/python/contextcompany/feedback.py
+++ b/packages/python/contextcompany/feedback.py
@@ -22,7 +22,7 @@ def submit_feedback(
         )
 
     # Get API key
-    from .config import get_url
+    from .config import assert_safe_url, get_url
     api_key = api_key or os.getenv("TCC_API_KEY")
     if not api_key:
         print("[TCC] Cannot submit feedback: TCC_API_KEY environment variable is not set")
@@ -34,6 +34,14 @@ def submit_feedback(
         or os.getenv("TCC_FEEDBACK_URL")
         or get_url("/v1/feedback", api_key=api_key)
     )
+
+    # Never attach the API key / send feedback to a non-TCC origin, even if the
+    # endpoint was overridden via tcc_url or a hijacked TCC_FEEDBACK_URL env var.
+    try:
+        assert_safe_url(feedback_url)
+    except ValueError as e:
+        print(f"[TCC] Cannot submit feedback: {e}")
+        return False
 
     # Prepare request
     payload: dict = {"runId": run_id}

--- a/packages/python/contextcompany/langchain/base.py
+++ b/packages/python/contextcompany/langchain/base.py
@@ -7,6 +7,7 @@ from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExport
 from ..otel import RunIdSpanProcessor, TraceBatchSpanProcessor
 from .exporter import RunIdFixingExporter
 from .._utils import _debug
+from ..config import assert_safe_url
 
 
 def create_tracer_provider(resource_attributes: Optional[dict] = None) -> TracerProvider:
@@ -15,6 +16,8 @@ def create_tracer_provider(resource_attributes: Optional[dict] = None) -> Tracer
 
 
 def create_otlp_exporter(endpoint: str, api_key: str, headers: Optional[dict] = None) -> OTLPSpanExporter:
+    # Never attach the API key / send telemetry to a non-TCC origin.
+    assert_safe_url(endpoint)
     exporter_headers = {"Authorization": f"Bearer {api_key}"}
     if headers:
         exporter_headers.update(headers)

--- a/packages/python/contextcompany/litellm/callback.py
+++ b/packages/python/contextcompany/litellm/callback.py
@@ -28,10 +28,12 @@ class TCCCallback(CustomLogger):
     """Exports each LLM call to TCC as an OTEL span with metadata.tcc.runId."""
 
     def __init__(self, api_key=None, endpoint=None, service_name="litellm"):
-        from ..config import get_api_key, get_url
+        from ..config import assert_safe_url, get_api_key, get_url
 
         api_key = get_api_key(api_key)
         endpoint = endpoint or get_url("/v1/otel-steps", api_key=api_key)
+        # Never attach the API key / send telemetry to a non-TCC origin.
+        assert_safe_url(endpoint)
 
         exporter = OTLPSpanExporter(
             endpoint=endpoint,

--- a/packages/python/tests/test_config.py
+++ b/packages/python/tests/test_config.py
@@ -1,7 +1,7 @@
 import os
 import unittest
 
-from contextcompany.config import normalize_base_url
+from contextcompany.config import assert_safe_url, normalize_base_url
 
 
 class NormalizeBaseUrlTests(unittest.TestCase):
@@ -40,4 +40,39 @@ class NormalizeBaseUrlTests(unittest.TestCase):
         self.assertEqual(
             normalize_base_url("https://self-hosted.example/"),
             "https://self-hosted.example",
+        )
+
+
+class AssertSafeUrlTests(unittest.TestCase):
+    def tearDown(self):
+        os.environ.pop("TCC_ALLOW_UNSAFE_BASE_URL", None)
+
+    def test_allows_official_and_localhost_endpoints(self):
+        for url in (
+            "https://api.thecontext.company/v1/traces",
+            "https://dev.thecontext.company/v1/custom",
+            "http://localhost:8787/v1/feedback",
+        ):
+            self.assertEqual(assert_safe_url(url), url)
+
+    def test_refuses_arbitrary_origins(self):
+        with self.assertRaisesRegex(ValueError, "Refusing to send credentials"):
+            assert_safe_url("https://evil.example/v1/traces")
+
+        # A look-alike host that merely embeds the allowed domain must be rejected.
+        with self.assertRaisesRegex(ValueError, "Refusing to send credentials"):
+            assert_safe_url("https://api.thecontext.company.evil.example/v1/traces")
+
+    def test_raises_on_malformed_url(self):
+        with self.assertRaisesRegex(ValueError, "Invalid TCC URL"):
+            assert_safe_url("not a url")
+
+    def test_allows_arbitrary_origins_only_with_unsafe_opt_in(self):
+        with self.assertRaisesRegex(ValueError, "Refusing to send credentials"):
+            assert_safe_url("https://self-hosted.example/v1/traces")
+
+        os.environ["TCC_ALLOW_UNSAFE_BASE_URL"] = "1"
+        self.assertEqual(
+            assert_safe_url("https://self-hosted.example/v1/traces"),
+            "https://self-hosted.example/v1/traces",
         )

--- a/packages/ts/api/src/config.test.ts
+++ b/packages/ts/api/src/config.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from "vitest";
-import { normalizeTCCBaseUrl } from "./config";
+import { assertSafeTCCUrl, normalizeTCCBaseUrl } from "./config";
 
 const OLD_ENV = process.env.TCC_ALLOW_UNSAFE_BASE_URL;
 
@@ -36,5 +36,44 @@ describe("normalizeTCCBaseUrl", () => {
     expect(normalizeTCCBaseUrl("https://self-hosted.example/")).toBe(
       "https://self-hosted.example"
     );
+  });
+});
+
+describe("assertSafeTCCUrl", () => {
+  it("allows official TCC and localhost endpoints", () => {
+    expect(() =>
+      assertSafeTCCUrl("https://api.thecontext.company/v1/traces")
+    ).not.toThrow();
+    expect(() =>
+      assertSafeTCCUrl("https://dev.thecontext.company/v1/custom")
+    ).not.toThrow();
+    expect(() =>
+      assertSafeTCCUrl("http://localhost:8787/v1/feedback")
+    ).not.toThrow();
+  });
+
+  it("refuses to send credentials to arbitrary origins", () => {
+    expect(() => assertSafeTCCUrl("https://evil.example/v1/traces")).toThrow(
+      /Refusing to send credentials/
+    );
+    // A look-alike host that merely embeds the allowed domain must be rejected.
+    expect(() =>
+      assertSafeTCCUrl("https://api.thecontext.company.evil.example/v1/traces")
+    ).toThrow(/Refusing to send credentials/);
+  });
+
+  it("throws on malformed URLs", () => {
+    expect(() => assertSafeTCCUrl("not a url")).toThrow(/Invalid TCC URL/);
+  });
+
+  it("allows arbitrary origins only with the unsafe opt-in", () => {
+    expect(() =>
+      assertSafeTCCUrl("https://self-hosted.example/v1/traces")
+    ).toThrow(/Refusing to send credentials/);
+
+    process.env.TCC_ALLOW_UNSAFE_BASE_URL = "1";
+    expect(() =>
+      assertSafeTCCUrl("https://self-hosted.example/v1/traces")
+    ).not.toThrow();
   });
 });

--- a/packages/ts/api/src/config.ts
+++ b/packages/ts/api/src/config.ts
@@ -13,6 +13,14 @@ function isLocalhostOrigin(origin: string): boolean {
   return /^https?:\/\/(localhost|127\.0\.0\.1|\[::1\])(:\d+)?$/.test(origin);
 }
 
+/**
+ * Whether `origin` is a TCC-controlled origin the SDK may send the API key and
+ * telemetry to without an explicit opt-in.
+ */
+function isAllowedTCCOrigin(origin: string): boolean {
+  return ALLOWED_REMOTE_ORIGINS.has(origin) || isLocalhostOrigin(origin);
+}
+
 export function normalizeTCCBaseUrl(url: string): string {
   let parsed: URL;
   try {
@@ -22,19 +30,40 @@ export function normalizeTCCBaseUrl(url: string): string {
   }
 
   const base = parsed.origin + parsed.pathname.replace(/\/+$/, "");
-  if (
-    ALLOWED_REMOTE_ORIGINS.has(parsed.origin) ||
-    isLocalhostOrigin(parsed.origin)
-  ) {
-    return base;
-  }
-
-  if (isUnsafeBaseUrlAllowed()) {
+  if (isAllowedTCCOrigin(parsed.origin) || isUnsafeBaseUrlAllowed()) {
     return base;
   }
 
   throw new Error(
     `[TCC] Refusing unsafe TCC base URL (${base}). Use ${PROD_BASE}, ${DEV_BASE}, localhost, or set TCC_ALLOW_UNSAFE_BASE_URL=1 for self-hosted testing.`
+  );
+}
+
+/**
+ * Defense-in-depth guard for the network sinks that attach the API key
+ * (`Authorization: Bearer …`) and ship telemetry. Throws unless `url` targets
+ * an allowed TCC origin (prod/dev/localhost) or the operator explicitly opted
+ * into self-hosting via `TCC_ALLOW_UNSAFE_BASE_URL=1`.
+ *
+ * This complements {@link normalizeTCCBaseUrl}: even if an endpoint reaches a
+ * sink without passing through base-URL normalization (e.g. an explicit
+ * endpoint override, or a hijacked `TCC_BASE_URL` / `TCC_FEEDBACK_URL`), the
+ * API key and trace data are never sent to an untrusted host.
+ */
+export function assertSafeTCCUrl(url: string): void {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new Error(`[TCC] Invalid TCC URL: ${url}`);
+  }
+
+  if (isAllowedTCCOrigin(parsed.origin) || isUnsafeBaseUrlAllowed()) {
+    return;
+  }
+
+  throw new Error(
+    `[TCC] Refusing to send credentials to unsafe URL (${parsed.origin}). Use ${PROD_BASE}, ${DEV_BASE}, localhost, or set TCC_ALLOW_UNSAFE_BASE_URL=1 for self-hosted testing.`
   );
 }
 

--- a/packages/ts/claude/src/claude.ts
+++ b/packages/ts/claude/src/claude.ts
@@ -171,7 +171,9 @@ async function sendToAuthTagger(payload: {
   sessionId?: string | null;
   userPrompt?: string | null;
 }): Promise<void> {
-  const { getTCCApiKey, getTCCUrl } = await import("@contextcompany/api");
+  const { assertSafeTCCUrl, getTCCApiKey, getTCCUrl } = await import(
+    "@contextcompany/api"
+  );
 
   const apiKey = getTCCApiKey();
 
@@ -181,6 +183,14 @@ async function sendToAuthTagger(payload: {
   }
 
   const endpoint = getTCCUrl("/v1/claude", apiKey);
+
+  try {
+    // Never attach the API key / send telemetry to a non-TCC origin.
+    assertSafeTCCUrl(endpoint);
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    return;
+  }
 
   if (DEBUG_ENABLED) {
     console.log("[TCC Debug] Payload:", JSON.stringify(payload, null, 2));

--- a/packages/ts/custom/src/transport.ts
+++ b/packages/ts/custom/src/transport.ts
@@ -1,4 +1,4 @@
-import { getTCCApiKey, getTCCUrl } from "@contextcompany/api";
+import { assertSafeTCCUrl, getTCCApiKey, getTCCUrl } from "@contextcompany/api";
 import { getConfig } from "./config";
 
 function resolveApiKey(): string | undefined {
@@ -58,6 +58,15 @@ export async function send(payload: Record<string, unknown>): Promise<void> {
   }
 
   const url = resolveUrl(apiKey);
+  try {
+    // Never attach the API key / send payloads to a non-TCC origin, even if the
+    // endpoint was overridden via config or a hijacked env var.
+    assertSafeTCCUrl(url);
+  } catch (err) {
+    console.error(err instanceof Error ? err.message : String(err));
+    return;
+  }
+
   const body = JSON.stringify(payload);
   debug("Sending payload to", url);
   debug("Payload:", payload);

--- a/packages/ts/langchain/src/callback-handler.ts
+++ b/packages/ts/langchain/src/callback-handler.ts
@@ -1,4 +1,4 @@
-import { getTCCApiKey, getTCCUrl } from "@contextcompany/api";
+import { assertSafeTCCUrl, getTCCApiKey, getTCCUrl } from "@contextcompany/api";
 import type { AgentAction, AgentFinish } from "@langchain/core/agents";
 import {
   BaseCallbackHandler,
@@ -466,6 +466,8 @@ export class TCCCallbackHandler
     this.endpoint =
       config.endpoint ||
       getTCCUrl("/v1/custom", apiKey);
+    // Refuse a non-TCC endpoint so the API key / telemetry can't be exfiltrated.
+    assertSafeTCCUrl(this.endpoint);
     this.fixedRunId = config.runId;
     this.sessionId = config.sessionId;
     this.conversational = config.conversational ?? false;

--- a/packages/ts/mastra/src/exporter.ts
+++ b/packages/ts/mastra/src/exporter.ts
@@ -6,7 +6,7 @@ import {
   TracingConfig,
 } from "@mastra/core/ai-tracing";
 import { randomUUID } from "crypto";
-import { getTCCApiKey, getTCCUrl } from "@contextcompany/api";
+import { assertSafeTCCUrl, getTCCApiKey, getTCCUrl } from "@contextcompany/api";
 import type { TCCMastraExporterConfig } from "./types";
 
 export class TCCMastraExporter implements AITracingExporter {
@@ -30,6 +30,8 @@ export class TCCMastraExporter implements AITracingExporter {
     this.endpoint =
       config.endpoint ||
       getTCCUrl("/v1/mastra", apiKey);
+    // Refuse a non-TCC endpoint so the API key / telemetry can't be exfiltrated.
+    assertSafeTCCUrl(this.endpoint);
     this.debug = config.debug || false;
   }
 

--- a/packages/ts/openclaw/src/plugin.ts
+++ b/packages/ts/openclaw/src/plugin.ts
@@ -10,7 +10,7 @@
  * All parsing/transformation happens server-side.
  */
 
-import { getTCCApiKey, getTCCUrl } from "@contextcompany/api";
+import { assertSafeTCCUrl, getTCCApiKey, getTCCUrl } from "@contextcompany/api";
 import type {
   ActiveSession,
   OpenClawHandle,
@@ -138,6 +138,21 @@ function registerHooks(
       ? pluginConfig.endpoint
       : null) ??
     getTCCUrl("/v1/openclaw", apiKey);
+
+  try {
+    // Never attach the API key / send runs to a non-TCC origin, even if the
+    // endpoint was overridden via config or a hijacked env var.
+    assertSafeTCCUrl(url);
+  } catch (err) {
+    log.warn(err instanceof Error ? err.message : String(err));
+    return {
+      getRunId: () => null,
+      getRunIdForSession: () => null,
+      setRunId: () => {},
+      setMetadata: () => {},
+      setRunContext: () => {},
+    };
+  }
 
   log.info(`exporting runs to ${url}`);
 

--- a/packages/ts/otel/src/exporters/json/OTLPHttpJsonTraceExporter.ts
+++ b/packages/ts/otel/src/exporters/json/OTLPHttpJsonTraceExporter.ts
@@ -5,6 +5,7 @@ import type { ExportResult } from "@opentelemetry/core";
 import { type ReadableSpan, SpanExporter } from "@opentelemetry/sdk-trace-base";
 import { JsonTraceSerializer } from "@opentelemetry/otlp-transformer/build/src/trace/json/trace";
 import { diag } from "@opentelemetry/api";
+import { assertSafeTCCUrl } from "@contextcompany/api";
 import { debug } from "../../internal/logger";
 
 type OTLPExporterConfig = {
@@ -22,6 +23,10 @@ export class OTLPHttpJsonTraceExporter implements SpanExporter {
   private _shutdownOnce = { isCalled: false };
 
   constructor(config: OTLPExporterConfig) {
+    // Refuse to ship spans (and the bearer token in `headers`) to an origin
+    // that isn't TCC-controlled, so a hijacked endpoint can't exfiltrate the
+    // API key or trace data.
+    assertSafeTCCUrl(config.url);
     this._url = config.url;
     this._headers = config.headers;
   }

--- a/packages/ts/pi/src/sender.ts
+++ b/packages/ts/pi/src/sender.ts
@@ -1,4 +1,4 @@
-import { getTCCApiKey, getTCCUrl } from "@contextcompany/api";
+import { assertSafeTCCUrl, getTCCApiKey, getTCCUrl } from "@contextcompany/api";
 import { debug } from "./logger";
 
 const MAX_RETRIES = 2;
@@ -45,6 +45,16 @@ export function createSender(
   }
 
   const url = resolveUrl(config, apiKey);
+
+  try {
+    // Never attach the API key / send telemetry to a non-TCC origin, even if
+    // the endpoint was overridden via config or a hijacked env var.
+    assertSafeTCCUrl(url);
+  } catch (err) {
+    console.error(err instanceof Error ? err.message : String(err));
+    return async () => {};
+  }
+
   debug(`TCC endpoint: ${url}`);
 
   return async (payload: unknown): Promise<void> => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 🎯 Changes

Bug fix (security hardening) for the Oneleet pentest finding **TC-006**: _Telemetry and API Key Exfiltration via `TCC_BASE_URL` Environment Hijacking_.

Every TS and Python SDK package attaches `Authorization: Bearer <TCC_API_KEY>` and ships trace data (prompts, responses, tool calls) to a telemetry endpoint. Base‑URL normalization for `TCC_BASE_URL` already exists in `config.ts`/`config.py`, but the actual network sinks trusted whatever URL they were handed, and Python's `TCC_FEEDBACK_URL` path skipped normalization entirely — so a hijacked env var or an explicit endpoint override could still exfiltrate the key and traces.

This PR adds a single shared origin‑allowlist guard and enforces it at **every** sink that sends the API key, so credentials/telemetry can never leave for a non‑TCC origin.

**Shared guards (single source of truth):**
- `@contextcompany/api` → new exported `assertSafeTCCUrl(url)` (refactors the allowlist logic shared with `normalizeTCCBaseUrl`).
- `contextcompany.config` → new exported `assert_safe_url(url)` (refactors `_split_origin` / `_is_origin_allowed`, shared with `normalize_base_url`).

The guard accepts only TCC‑controlled origins (`api.thecontext.company`, `dev.thecontext.company`, `localhost`); anything else requires the existing explicit `TCC_ALLOW_UNSAFE_BASE_URL=1` self‑hosting opt‑in.

**TS sinks hardened** (each bundles its own copy of `@contextcompany/api`, so all get a patch release via the changeset):
- `otel` `OTLPHttpJsonTraceExporter` (constructor — fail fast)
- `custom`, `claude`, `pi`, `openclaw` transports (log + skip send)
- `mastra`, `langchain` exporters (constructor — fail fast)

**Python sinks hardened:**
- `feedback.py` — now validates `feedback_url` (closes the unvalidated `TCC_FEEDBACK_URL` env‑hijack gap)
- `_utils._send_payload` (covers custom + crewai), `claude`, `agno`, `langchain/base`, `litellm`

## ✅ Checklist

- [x] I have followed the steps listed in the Contributing guide.
- [x] If necessary, I have added documentation related to the changes made. _(JSDoc/docstrings on the new guards; behavior matches the documented `TCC_ALLOW_UNSAFE_BASE_URL` self-hosting escape hatch.)_
- [x] If applicable, I have added or updated the tests related to the changes made. _(New `assertSafeTCCUrl` vitest cases and `assert_safe_url` unittest cases, incl. look‑alike host + malformed URL + unsafe opt‑in. `pnpm test`: 38 passing; Python config tests: 7 passing; all TS packages build.)_

## 🔒 Related Issues

Resolves pentest finding TC-006. Builds on the earlier pentest remediation in #98 / #102.

### Notes for reviewers
- Legitimate self‑hosting is unaffected: set `TCC_ALLOW_UNSAFE_BASE_URL=1` (same flag already used by base‑URL normalization). Local dev (`localhost`) and prod/dev endpoints work unchanged.
- A changeset (`.changeset/secure-telemetry-sink-urls.md`) patch‑bumps all 8 touched TS packages so the bundled guard ships everywhere. Python releases via the conventional‑commit `fix(python):` scope.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-71f53f7a-2f4f-495c-b097-e26a1a7f308f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-71f53f7a-2f4f-495c-b097-e26a1a7f308f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

