### PR TITLE
fix(examples): secure unauthenticated chat API (TCC-164)

### DIFF
--- a/examples/nextjs-aisdk/.env.example
+++ b/examples/nextjs-aisdk/.env.example
@@ -15,3 +15,8 @@ NEXT_PUBLIC_TCC_EXAMPLE_API_TOKEN=
 # For throwaway local-only demos, you can bypass the example API token gate.
 # Do not set this for deployed examples.
 TCC_ALLOW_UNAUTHENTICATED_EXAMPLE_APIS=
+
+# Optional: tune the built-in best-effort rate limiter (per client, fixed window).
+# Set either value to 0 to disable. Defaults: 20 requests / 60000 ms.
+# TCC_EXAMPLE_RATE_LIMIT_MAX=20
+# TCC_EXAMPLE_RATE_LIMIT_WINDOW_MS=60000

--- a/examples/nextjs-aisdk/README.md
+++ b/examples/nextjs-aisdk/README.md
@@ -164,6 +164,27 @@ The weather agent is defined inline in `src/app/api/chat/route.ts` and demonstra
 3. Backend validates and submits to TCC via `submitFeedback()`
 4. TCC links feedback to the specific AI interaction
 
+## API Route Security
+
+`/api/chat` and `/api/feedback` use your server-side keys, so they are guarded
+against unauthenticated abuse and unexpected spend:
+
+- **Authentication** (`src/app/api/_example-auth.ts`): requests must send the
+  `x-tcc-example-token` header matching `TCC_EXAMPLE_API_TOKEN`. If no token is
+  configured the routes return `403` (set `TCC_ALLOW_UNAUTHENTICATED_EXAMPLE_APIS=1`
+  for throwaway local demos). Tokens are compared with `timingSafeEqual`.
+- **Rate limiting + input validation** (`src/app/api/_example-guard.ts`): a
+  best-effort per-client fixed-window rate limiter (defaults to 20 requests /
+  60s, tunable via `TCC_EXAMPLE_RATE_LIMIT_MAX` / `TCC_EXAMPLE_RATE_LIMIT_WINDOW_MS`),
+  plus a request-body size cap and a bound on the number of messages.
+- **Session ID sanitization**: the client-supplied `sessionId` is validated
+  before it reaches telemetry metadata; anything malformed is replaced with a
+  server-generated id so untrusted input never lands in traces unchecked.
+
+These controls are intentionally simple and meant for an example. For production,
+front the endpoints with real authentication and enforce limits in a durable,
+shared store (e.g. Upstash/Redis) keyed by an authenticated user.
+
 ## TCC Dashboard
 
 After running the application and generating some conversations:

--- a/examples/nextjs-aisdk/src/app/api/_example-guard.ts
+++ b/examples/nextjs-aisdk/src/app/api/_example-guard.ts
@@ -1,0 +1,173 @@
+import { NextResponse } from "next/server";
+import type { UIMessage } from "ai";
+
+/**
+ * Best-effort guards for the example API routes: a lightweight rate limiter and
+ * request-body validation. Together with `authorizeExampleRequest` these bound
+ * how much the demo's server-side OpenAI key can be abused by unauthenticated
+ * or scripted traffic (the concern raised in the pentest finding).
+ *
+ * These are intentionally simple and NOT production-grade:
+ *   - Rate-limit state lives in process memory, so it resets on redeploy and is
+ *     not shared across serverless instances or regions.
+ *   - The client identifier comes from forwarded headers, which can be spoofed
+ *     behind an untrusted proxy.
+ *
+ * For real deployments, put auth in front of the endpoint and enforce limits in
+ * a durable, shared store (e.g. Upstash/Redis) keyed by an authenticated user.
+ */
+
+// Reject oversized bodies before we hand them to the model — a single huge
+// prompt can be expensive, so cap it well above a normal demo conversation.
+const MAX_BODY_BYTES = 128 * 1024; // 128 KB
+const MAX_MESSAGES = 100;
+const SESSION_ID_PATTERN = /^[A-Za-z0-9_-]{1,128}$/;
+
+const RATE_LIMIT_MAX = parseCount(process.env.TCC_EXAMPLE_RATE_LIMIT_MAX, 20);
+const RATE_LIMIT_WINDOW_MS = parseCount(
+  process.env.TCC_EXAMPLE_RATE_LIMIT_WINDOW_MS,
+  60_000
+);
+
+type RateBucket = { count: number; resetAt: number };
+const rateBuckets = new Map<string, RateBucket>();
+
+export type ChatRequest = {
+  messages: UIMessage[];
+  sessionId?: string;
+};
+
+export type ChatRequestResult =
+  | { ok: true; data: ChatRequest }
+  | { ok: false; response: NextResponse };
+
+/**
+ * Fixed-window rate limit per client. Returns a 429 response when the limit is
+ * exceeded, or `null` to let the request proceed. Set either env knob to 0 to
+ * disable.
+ */
+export function enforceExampleRateLimit(
+  request: Request,
+  scope = "example"
+): NextResponse | null {
+  if (RATE_LIMIT_MAX <= 0 || RATE_LIMIT_WINDOW_MS <= 0) return null;
+
+  const now = Date.now();
+  pruneExpiredBuckets(now);
+
+  const key = `${scope}:${clientIdentifier(request)}`;
+  const bucket = rateBuckets.get(key);
+
+  if (!bucket || now >= bucket.resetAt) {
+    rateBuckets.set(key, { count: 1, resetAt: now + RATE_LIMIT_WINDOW_MS });
+    return null;
+  }
+
+  if (bucket.count >= RATE_LIMIT_MAX) {
+    const retryAfterSeconds = Math.max(
+      1,
+      Math.ceil((bucket.resetAt - now) / 1000)
+    );
+    return NextResponse.json(
+      { error: "Too many requests. Please slow down." },
+      { status: 429, headers: { "Retry-After": String(retryAfterSeconds) } }
+    );
+  }
+
+  bucket.count += 1;
+  return null;
+}
+
+/**
+ * Reads and validates the chat request body: caps its size, ensures `messages`
+ * is a non-empty, reasonably sized array, and sanitizes the client-supplied
+ * `sessionId` so untrusted input never reaches telemetry unchecked.
+ */
+export async function readChatRequest(
+  request: Request
+): Promise<ChatRequestResult> {
+  const raw = await request.text();
+
+  if (byteLength(raw) > MAX_BODY_BYTES) {
+    return {
+      ok: false,
+      response: NextResponse.json(
+        { error: "Request body too large" },
+        { status: 413 }
+      ),
+    };
+  }
+
+  let body: unknown;
+  try {
+    body = JSON.parse(raw);
+  } catch {
+    return badRequest("Invalid JSON body");
+  }
+
+  if (typeof body !== "object" || body === null) {
+    return badRequest("Request body must be a JSON object");
+  }
+
+  const { messages, sessionId } = body as {
+    messages?: unknown;
+    sessionId?: unknown;
+  };
+
+  if (!Array.isArray(messages) || messages.length === 0) {
+    return badRequest("`messages` must be a non-empty array");
+  }
+
+  if (messages.length > MAX_MESSAGES) {
+    return badRequest(`Too many messages (max ${MAX_MESSAGES})`);
+  }
+
+  return {
+    ok: true,
+    data: {
+      messages: messages as UIMessage[],
+      sessionId: sanitizeSessionId(sessionId),
+    },
+  };
+}
+
+/**
+ * Returns the value only when it is a safe, bounded session identifier;
+ * otherwise `undefined` so the caller can fall back to a server-generated id.
+ */
+export function sanitizeSessionId(value: unknown): string | undefined {
+  return typeof value === "string" && SESSION_ID_PATTERN.test(value)
+    ? value
+    : undefined;
+}
+
+function badRequest(message: string): ChatRequestResult {
+  return {
+    ok: false,
+    response: NextResponse.json({ error: message }, { status: 400 }),
+  };
+}
+
+function clientIdentifier(request: Request): string {
+  const forwardedFor = request.headers.get("x-forwarded-for");
+  const firstForwarded = forwardedFor?.split(",")[0]?.trim();
+  if (firstForwarded) return firstForwarded;
+
+  return request.headers.get("x-real-ip")?.trim() || "local";
+}
+
+function pruneExpiredBuckets(now: number): void {
+  for (const [key, bucket] of rateBuckets) {
+    if (now >= bucket.resetAt) rateBuckets.delete(key);
+  }
+}
+
+function byteLength(value: string): number {
+  return new TextEncoder().encode(value).length;
+}
+
+function parseCount(value: string | undefined, fallback: number): number {
+  if (value === undefined) return fallback;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback;
+}

--- a/examples/nextjs-aisdk/src/app/api/chat/route.ts
+++ b/examples/nextjs-aisdk/src/app/api/chat/route.ts
@@ -1,7 +1,9 @@
 import { randomUUID } from "crypto";
+import { NextResponse } from "next/server";
 import { openai } from "@ai-sdk/openai";
 import { convertToModelMessages, stepCountIs, streamText } from "ai";
 import { authorizeExampleRequest } from "../_example-auth";
+import { enforceExampleRateLimit, readChatRequest } from "../_example-guard";
 import { weatherTools } from "./agent";
 
 export const maxDuration = 60;
@@ -10,16 +12,32 @@ export async function POST(req: Request) {
   const unauthorized = authorizeExampleRequest(req);
   if (unauthorized) return unauthorized;
 
-  const body = await req.json();
-  const { messages } = body;
+  const rateLimited = enforceExampleRateLimit(req, "chat");
+  if (rateLimited) return rateLimited;
+
+  const parsed = await readChatRequest(req);
+  if (!parsed.ok) return parsed.response;
+  const { messages, sessionId: clientSessionId } = parsed.data;
+
+  let modelMessages;
+  try {
+    modelMessages = await convertToModelMessages(messages);
+  } catch {
+    return NextResponse.json(
+      { error: "Invalid messages payload" },
+      { status: 400 }
+    );
+  }
 
   // TCC tracking IDs
-  const sessionId = body.sessionId; // Track conversation session across requests
+  // Fall back to a server-generated id when the client omits or sends an
+  // invalid sessionId, so untrusted input never lands in telemetry unchecked.
+  const sessionId = clientSessionId ?? randomUUID(); // Track conversation session across requests
   const runId = randomUUID(); // Track this specific AI call
 
   const result = streamText({
     model: openai("gpt-4o"),
-    messages: await convertToModelMessages(messages),
+    messages: modelMessages,
     system: `You are a helpful weather assistant. Use getLocation to suggest a city, or getWeather to check the weather for a specific location.`,
     tools: weatherTools,
     stopWhen: stepCountIs(10),

--- a/examples/nextjs-widget/.env.example
+++ b/examples/nextjs-widget/.env.example
@@ -2,3 +2,18 @@ OPENAI_API_KEY=
 
 # Not required for local mode:
 # TCC_API_KEY=
+
+# Protect this example's /api/chat endpoint so it can't be used to spend your
+# OpenAI key without authorization. Set the same value in both variables so the
+# browser demo can call the route.
+TCC_EXAMPLE_API_TOKEN=
+NEXT_PUBLIC_TCC_EXAMPLE_API_TOKEN=
+
+# For throwaway local-only demos you can bypass the token gate instead.
+# Do not set this for a deployed example.
+TCC_ALLOW_UNAUTHENTICATED_EXAMPLE_APIS=
+
+# Optional: tune the built-in best-effort rate limiter (per client, fixed window).
+# Set either value to 0 to disable. Defaults: 20 requests / 60000 ms.
+# TCC_EXAMPLE_RATE_LIMIT_MAX=20
+# TCC_EXAMPLE_RATE_LIMIT_WINDOW_MS=60000

--- a/examples/nextjs-widget/README.md
+++ b/examples/nextjs-widget/README.md
@@ -53,11 +53,19 @@ yarn install
 cp .env.example .env
 ```
 
-Edit `.env` and add your OpenAI API key:
+Edit `.env` and add your OpenAI API key. The `/api/chat` route is protected by
+default so it can't be used to spend your OpenAI key without authorization, so
+also set a demo token (used by both the server and the browser):
 
 ```env
 OPENAI_API_KEY=your_openai_api_key_here
+TCC_EXAMPLE_API_TOKEN=choose_a_local_demo_token
+NEXT_PUBLIC_TCC_EXAMPLE_API_TOKEN=choose_a_local_demo_token
 ```
+
+For a throwaway local-only demo you can instead bypass the token gate with
+`TCC_ALLOW_UNAUTHENTICATED_EXAMPLE_APIS=1`; do not use that setting for a
+deployed example.
 
 4. **Run the development server:**
 
@@ -143,6 +151,24 @@ registerOTelTCC({ local: true });
 ```
 
 The `local: true` option configures telemetry to work with the local widget instead of sending data to a remote server.
+
+## API Route Security
+
+The `/api/chat` route calls OpenAI with your server-side `OPENAI_API_KEY`, so it
+is guarded to prevent unauthenticated abuse and unexpected spend:
+
+- **Authentication** (`app/api/_example-auth.ts`): requests must send the
+  `x-tcc-example-token` header matching `TCC_EXAMPLE_API_TOKEN`. If no token is
+  configured the route returns `403` (set `TCC_ALLOW_UNAUTHENTICATED_EXAMPLE_APIS=1`
+  for throwaway local demos). Tokens are compared with `timingSafeEqual`.
+- **Rate limiting + input validation** (`app/api/_example-guard.ts`): a
+  best-effort per-client fixed-window rate limiter (defaults to 20 requests /
+  60s, tunable via `TCC_EXAMPLE_RATE_LIMIT_MAX` / `TCC_EXAMPLE_RATE_LIMIT_WINDOW_MS`),
+  plus a request-body size cap and a bound on the number of messages.
+
+These controls are intentionally simple and meant for an example. For production,
+front the endpoint with real authentication and enforce limits in a durable,
+shared store (e.g. Upstash/Redis) keyed by an authenticated user.
 
 ## Learn More
 

--- a/examples/nextjs-widget/app/api/_example-auth.ts
+++ b/examples/nextjs-widget/app/api/_example-auth.ts
@@ -1,0 +1,37 @@
+import { timingSafeEqual } from "crypto";
+import { NextResponse } from "next/server";
+
+const EXAMPLE_TOKEN_HEADER = "x-tcc-example-token";
+
+export function authorizeExampleRequest(request: Request): NextResponse | null {
+  if (process.env.TCC_ALLOW_UNAUTHENTICATED_EXAMPLE_APIS === "1") {
+    return null;
+  }
+
+  const expectedToken = process.env.TCC_EXAMPLE_API_TOKEN;
+  if (!expectedToken) {
+    return NextResponse.json(
+      {
+        error:
+          "Example API routes are disabled. Set TCC_EXAMPLE_API_TOKEN or TCC_ALLOW_UNAUTHENTICATED_EXAMPLE_APIS=1 for local-only demos.",
+      },
+      { status: 403 }
+    );
+  }
+
+  if (!tokensEqual(request.headers.get(EXAMPLE_TOKEN_HEADER), expectedToken)) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  return null;
+}
+
+function tokensEqual(provided: string | null, expected: string): boolean {
+  const providedBuffer = Buffer.from(provided ?? "");
+  const expectedBuffer = Buffer.from(expected);
+
+  return (
+    providedBuffer.length === expectedBuffer.length &&
+    timingSafeEqual(providedBuffer, expectedBuffer)
+  );
+}

--- a/examples/nextjs-widget/app/api/_example-guard.ts
+++ b/examples/nextjs-widget/app/api/_example-guard.ts
@@ -1,0 +1,173 @@
+import { NextResponse } from "next/server";
+import type { UIMessage } from "ai";
+
+/**
+ * Best-effort guards for the example API routes: a lightweight rate limiter and
+ * request-body validation. Together with `authorizeExampleRequest` these bound
+ * how much the demo's server-side OpenAI key can be abused by unauthenticated
+ * or scripted traffic (the concern raised in the pentest finding).
+ *
+ * These are intentionally simple and NOT production-grade:
+ *   - Rate-limit state lives in process memory, so it resets on redeploy and is
+ *     not shared across serverless instances or regions.
+ *   - The client identifier comes from forwarded headers, which can be spoofed
+ *     behind an untrusted proxy.
+ *
+ * For real deployments, put auth in front of the endpoint and enforce limits in
+ * a durable, shared store (e.g. Upstash/Redis) keyed by an authenticated user.
+ */
+
+// Reject oversized bodies before we hand them to the model — a single huge
+// prompt can be expensive, so cap it well above a normal demo conversation.
+const MAX_BODY_BYTES = 128 * 1024; // 128 KB
+const MAX_MESSAGES = 100;
+const SESSION_ID_PATTERN = /^[A-Za-z0-9_-]{1,128}$/;
+
+const RATE_LIMIT_MAX = parseCount(process.env.TCC_EXAMPLE_RATE_LIMIT_MAX, 20);
+const RATE_LIMIT_WINDOW_MS = parseCount(
+  process.env.TCC_EXAMPLE_RATE_LIMIT_WINDOW_MS,
+  60_000
+);
+
+type RateBucket = { count: number; resetAt: number };
+const rateBuckets = new Map<string, RateBucket>();
+
+export type ChatRequest = {
+  messages: UIMessage[];
+  sessionId?: string;
+};
+
+export type ChatRequestResult =
+  | { ok: true; data: ChatRequest }
+  | { ok: false; response: NextResponse };
+
+/**
+ * Fixed-window rate limit per client. Returns a 429 response when the limit is
+ * exceeded, or `null` to let the request proceed. Set either env knob to 0 to
+ * disable.
+ */
+export function enforceExampleRateLimit(
+  request: Request,
+  scope = "example"
+): NextResponse | null {
+  if (RATE_LIMIT_MAX <= 0 || RATE_LIMIT_WINDOW_MS <= 0) return null;
+
+  const now = Date.now();
+  pruneExpiredBuckets(now);
+
+  const key = `${scope}:${clientIdentifier(request)}`;
+  const bucket = rateBuckets.get(key);
+
+  if (!bucket || now >= bucket.resetAt) {
+    rateBuckets.set(key, { count: 1, resetAt: now + RATE_LIMIT_WINDOW_MS });
+    return null;
+  }
+
+  if (bucket.count >= RATE_LIMIT_MAX) {
+    const retryAfterSeconds = Math.max(
+      1,
+      Math.ceil((bucket.resetAt - now) / 1000)
+    );
+    return NextResponse.json(
+      { error: "Too many requests. Please slow down." },
+      { status: 429, headers: { "Retry-After": String(retryAfterSeconds) } }
+    );
+  }
+
+  bucket.count += 1;
+  return null;
+}
+
+/**
+ * Reads and validates the chat request body: caps its size, ensures `messages`
+ * is a non-empty, reasonably sized array, and sanitizes the client-supplied
+ * `sessionId` so untrusted input never reaches telemetry unchecked.
+ */
+export async function readChatRequest(
+  request: Request
+): Promise<ChatRequestResult> {
+  const raw = await request.text();
+
+  if (byteLength(raw) > MAX_BODY_BYTES) {
+    return {
+      ok: false,
+      response: NextResponse.json(
+        { error: "Request body too large" },
+        { status: 413 }
+      ),
+    };
+  }
+
+  let body: unknown;
+  try {
+    body = JSON.parse(raw);
+  } catch {
+    return badRequest("Invalid JSON body");
+  }
+
+  if (typeof body !== "object" || body === null) {
+    return badRequest("Request body must be a JSON object");
+  }
+
+  const { messages, sessionId } = body as {
+    messages?: unknown;
+    sessionId?: unknown;
+  };
+
+  if (!Array.isArray(messages) || messages.length === 0) {
+    return badRequest("`messages` must be a non-empty array");
+  }
+
+  if (messages.length > MAX_MESSAGES) {
+    return badRequest(`Too many messages (max ${MAX_MESSAGES})`);
+  }
+
+  return {
+    ok: true,
+    data: {
+      messages: messages as UIMessage[],
+      sessionId: sanitizeSessionId(sessionId),
+    },
+  };
+}
+
+/**
+ * Returns the value only when it is a safe, bounded session identifier;
+ * otherwise `undefined` so the caller can fall back to a server-generated id.
+ */
+export function sanitizeSessionId(value: unknown): string | undefined {
+  return typeof value === "string" && SESSION_ID_PATTERN.test(value)
+    ? value
+    : undefined;
+}
+
+function badRequest(message: string): ChatRequestResult {
+  return {
+    ok: false,
+    response: NextResponse.json({ error: message }, { status: 400 }),
+  };
+}
+
+function clientIdentifier(request: Request): string {
+  const forwardedFor = request.headers.get("x-forwarded-for");
+  const firstForwarded = forwardedFor?.split(",")[0]?.trim();
+  if (firstForwarded) return firstForwarded;
+
+  return request.headers.get("x-real-ip")?.trim() || "local";
+}
+
+function pruneExpiredBuckets(now: number): void {
+  for (const [key, bucket] of rateBuckets) {
+    if (now >= bucket.resetAt) rateBuckets.delete(key);
+  }
+}
+
+function byteLength(value: string): number {
+  return new TextEncoder().encode(value).length;
+}
+
+function parseCount(value: string | undefined, fallback: number): number {
+  if (value === undefined) return fallback;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback;
+}

--- a/examples/nextjs-widget/app/api/chat/route.ts
+++ b/examples/nextjs-widget/app/api/chat/route.ts
@@ -1,12 +1,9 @@
+import { NextResponse } from "next/server";
 import { openai } from "@ai-sdk/openai";
-import {
-  streamText,
-  UIMessage,
-  convertToModelMessages,
-  tool,
-  stepCountIs,
-} from "ai";
+import { convertToModelMessages, stepCountIs, streamText, tool } from "ai";
 import { z } from "zod";
+import { authorizeExampleRequest } from "../_example-auth";
+import { enforceExampleRateLimit, readChatRequest } from "../_example-guard";
 
 const getWeather = tool({
   description: "Get the weather for a given city",
@@ -34,11 +31,28 @@ const createTicket = tool({
 export const maxDuration = 30;
 
 export async function POST(req: Request) {
-  const { messages }: { messages: UIMessage[] } = await req.json();
+  const unauthorized = authorizeExampleRequest(req);
+  if (unauthorized) return unauthorized;
+
+  const rateLimited = enforceExampleRateLimit(req, "chat");
+  if (rateLimited) return rateLimited;
+
+  const parsed = await readChatRequest(req);
+  if (!parsed.ok) return parsed.response;
+
+  let modelMessages;
+  try {
+    modelMessages = convertToModelMessages(parsed.data.messages);
+  } catch {
+    return NextResponse.json(
+      { error: "Invalid messages payload" },
+      { status: 400 }
+    );
+  }
 
   const result = streamText({
     model: openai("gpt-4o"),
-    messages: convertToModelMessages(messages),
+    messages: modelMessages,
     tools: { getWeather, createTicket },
     stopWhen: stepCountIs(10),
     experimental_telemetry: { isEnabled: true },

--- a/examples/nextjs-widget/app/page.tsx
+++ b/examples/nextjs-widget/app/page.tsx
@@ -1,11 +1,27 @@
 "use client";
 
+import { useMemo, useState } from "react";
 import { useChat } from "@ai-sdk/react";
-import { useState } from "react";
+import { DefaultChatTransport } from "ai";
+
+const exampleApiToken = process.env.NEXT_PUBLIC_TCC_EXAMPLE_API_TOKEN;
 
 export default function Chat() {
   const [input, setInput] = useState("");
-  const { messages, sendMessage } = useChat();
+
+  // Send the example API token so the protected /api/chat route accepts the
+  // request. Omitted automatically for local-only demos that bypass the gate.
+  const transport = useMemo(
+    () =>
+      new DefaultChatTransport({
+        headers: exampleApiToken
+          ? { "x-tcc-example-token": exampleApiToken }
+          : undefined,
+      }),
+    []
+  );
+
+  const { messages, sendMessage } = useChat({ transport });
   return (
     <div className="flex flex-col w-full max-w-md py-24 mx-auto stretch">
       {messages.map((message) => (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 🎯 Changes

Security hardening (bug fix) for pentest finding TC-004: the example `/api/chat` endpoints allowed unauthenticated, unbounded `gpt-4o` invocation on the server-side `OPENAI_API_KEY`, enabling financial abuse. In `nextjs-aisdk` the client-supplied `sessionId` was also injected into telemetry metadata without validation.

**`examples/nextjs-widget`** (previously had no protection at all):

- **Authentication** — new `app/api/_example-auth.ts` token gate mirroring `nextjs-aisdk`. Secure-by-default: returns `403` unless `TCC_EXAMPLE_API_TOKEN` is set (checked against the `x-tcc-example-token` header with `timingSafeEqual`), or `TCC_ALLOW_UNAUTHENTICATED_EXAMPLE_APIS=1` is set for throwaway local demos.
- The client (`app/page.tsx`) now sends the token via `DefaultChatTransport` headers.

**Both examples** — new `_example-guard.ts` shared per example:

- **Rate limiting** — best-effort per-client fixed-window limiter (default 20 req / 60s, tunable via `TCC_EXAMPLE_RATE_LIMIT_MAX` / `TCC_EXAMPLE_RATE_LIMIT_WINDOW_MS`, `0` disables). Returns `429` with `Retry-After`.
- **Input validation** — rejects oversized bodies (`413`) and non-array / empty / oversized `messages` (`400`), and returns `400` on malformed message payloads instead of leaking an internal error.

**`examples/nextjs-aisdk`**:

- **Session ID sanitization** — the client `sessionId` is validated against `^[A-Za-z0-9_-]{1,128}$` before reaching telemetry; anything malformed (injection chars, newlines, oversized, non-string) is replaced with a server-generated UUID so untrusted input never lands in traces.

The controls are intentionally simple and scoped to the examples; each is documented in the example READMEs and `.env.example` files, with a note to use real auth + a durable rate-limit store (e.g. Upstash/Redis) in production.

### Verification

Ran both examples with `next dev` and exercised the endpoints with `curl`:

- No token → `403`; wrong token → `401`; valid token / bypass → passes guards and reaches the model (only fails on the test-dummy OpenAI key).
- Empty / non-array / invalid-JSON `messages` → `400`; ~200 KB body → `413`.
- `MAX=2` → 3rd request → `429` with `Retry-After`.
- Malicious `sessionId` (`evil; DROP TABLE traces;--`) is dropped in favor of a server-generated id; endpoint still responds.
- `tsc --noEmit` and `eslint` pass for both examples.

## ✅ Checklist

- [x] I have followed the steps listed in the Contributing guide.
- [x] If necessary, I have added documentation related to the changes made.
- [ ] If applicable, I have added or updated the tests related to the changes made. (Examples are demo apps without a test suite; verified manually via `curl`.)

## 🔒 Related Issues

Closes TCC-164
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0be926a5-9a9c-400d-9187-23317853e054"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0be926a5-9a9c-400d-9187-23317853e054"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

