### PR TITLE
fix(otel): keep serverless instances alive until span export completes

### DIFF
--- a/.changeset/serverless-export-reliability.md
+++ b/.changeset/serverless-export-reliability.md
@@ -1,0 +1,5 @@
+---
+"@contextcompany/otel": patch
+---
+
+Prevent span export loss on serverless runtimes and surface export failures. Span export requests are now registered with the Vercel request context's `waitUntil` (no-op elsewhere), so the function instance is kept alive until telemetry delivery completes instead of freezing the moment the response closes and killing the export mid-flight. The OTLP exporter now treats non-2xx ingest responses as export errors instead of silent successes, and run batch export failures are logged.

--- a/packages/ts/otel/src/RunBatchSpanProcessor.ts
+++ b/packages/ts/otel/src/RunBatchSpanProcessor.ts
@@ -209,6 +209,12 @@ export class RunBatchSpanProcessor implements SpanProcessor {
     }
 
     debug(`RunBatchSpanProcessor: Sending batch ${runId} to exporter`);
-    this.exporter.export(batch, (_result) => {});
+    this.exporter.export(batch, (result) => {
+      if (result.code !== 0) {
+        debug(
+          `RunBatchSpanProcessor: Failed to export batch ${runId}: ${result.error}`
+        );
+      }
+    });
   }
 }

--- a/packages/ts/otel/src/RunBatchSpanProcessor.ts
+++ b/packages/ts/otel/src/RunBatchSpanProcessor.ts
@@ -1,4 +1,5 @@
 import { Context } from "@opentelemetry/api";
+import { ExportResultCode } from "@opentelemetry/core";
 import {
   SpanProcessor,
   type ReadableSpan,
@@ -210,7 +211,7 @@ export class RunBatchSpanProcessor implements SpanProcessor {
 
     debug(`RunBatchSpanProcessor: Sending batch ${runId} to exporter`);
     this.exporter.export(batch, (result) => {
-      if (result.code !== 0) {
+      if (result.code !== ExportResultCode.SUCCESS) {
         debug(
           `RunBatchSpanProcessor: Failed to export batch ${runId}: ${result.error}`
         );

--- a/packages/ts/otel/src/exporters/json/OTLPHttpJsonTraceExporter.ts
+++ b/packages/ts/otel/src/exporters/json/OTLPHttpJsonTraceExporter.ts
@@ -6,6 +6,7 @@ import { type ReadableSpan, SpanExporter } from "@opentelemetry/sdk-trace-base";
 import { JsonTraceSerializer } from "@opentelemetry/otlp-transformer/build/src/trace/json/trace";
 import { diag } from "@opentelemetry/api";
 import { debug } from "../../internal/logger";
+import { waitUntil } from "../../internal/waitUntil";
 
 type OTLPExporterConfig = {
   url: string;
@@ -77,12 +78,21 @@ export class OTLPHttpJsonTraceExporter implements SpanExporter {
       },
     })
       .then((res) => {
+        // drain the body so the connection can be reused
+        void res.arrayBuffer().catch(() => undefined);
+        if (!res.ok) {
+          const message = `Failed to export ${spans.length} spans: HTTP ${res.status}`;
+          debug(message);
+          diag.error(`@contextcompany/otel: ${message}`);
+          onError(new Error(message) as OTLPExporterError);
+          return;
+        }
         debug(`Successfully exported ${spans.length} spans`);
         onSuccess();
-        void res.arrayBuffer().catch(() => undefined);
       })
       .catch((err) => {
         debug(`Error exporting ${spans.length} spans: ${err}`);
+        diag.error(`@contextcompany/otel: failed to export spans: ${err}`);
         onError(err as OTLPExporterError);
       })
       .finally(() => {
@@ -93,5 +103,12 @@ export class OTLPHttpJsonTraceExporter implements SpanExporter {
 
     // add to _sendingPromises so we can wait for them to complete in case shutdown() is called
     this._sendingPromises.push(promise);
+
+    // On serverless runtimes (Vercel), the instance can be frozen the moment
+    // the HTTP response closes — which is typically right when the run span
+    // ends and this export fires. Register the export with the platform's
+    // waitUntil so the invocation stays alive until delivery completes.
+    // No-op outside a serverless request context.
+    waitUntil(promise);
   }
 }

--- a/packages/ts/otel/src/exporters/json/OTLPHttpJsonTraceExporter.ts
+++ b/packages/ts/otel/src/exporters/json/OTLPHttpJsonTraceExporter.ts
@@ -77,16 +77,20 @@ export class OTLPHttpJsonTraceExporter implements SpanExporter {
         "User-Agent": "OTel-OTLP-Exporter-JavaScript/0.46.0",
       },
     })
-      .then((res) => {
-        // drain the body so the connection can be reused
-        void res.arrayBuffer().catch(() => undefined);
+      .then(async (res) => {
         if (!res.ok) {
-          const message = `Failed to export ${spans.length} spans: HTTP ${res.status}`;
+          const errorBody = await res
+            .text()
+            .then((text) => text.slice(0, 1024))
+            .catch(() => "");
+          const message = `Failed to export ${spans.length} spans: HTTP ${res.status}${errorBody ? ` ${errorBody}` : ""}`;
           debug(message);
           diag.error(`@contextcompany/otel: ${message}`);
           onError(new Error(message) as OTLPExporterError);
           return;
         }
+        // drain the body so the connection can be reused
+        void res.arrayBuffer().catch(() => undefined);
         debug(`Successfully exported ${spans.length} spans`);
         onSuccess();
       })

--- a/packages/ts/otel/src/internal/waitUntil.ts
+++ b/packages/ts/otel/src/internal/waitUntil.ts
@@ -1,0 +1,37 @@
+// Serverless platforms (Vercel in particular) freeze or terminate the
+// function instance as soon as the HTTP response finishes. Span exports
+// are triggered by span end, which typically happens at the same moment
+// the response closes — so a fire-and-forget export fetch can be killed
+// mid-flight and the run silently never reaches ingest.
+//
+// Vercel exposes a request context on a well-known global symbol whose
+// `waitUntil` keeps the instance alive until the given promise settles.
+// This is the same mechanism `@vercel/functions` uses under the hood. We
+// read it directly so the package works without any extra dependency and
+// without users changing their code. On non-Vercel runtimes the symbol is
+// absent and this is a no-op.
+
+const VERCEL_REQUEST_CONTEXT_SYMBOL = Symbol.for("@vercel/request-context");
+
+type VercelRequestContext = {
+  waitUntil?: (promise: Promise<unknown>) => void;
+};
+
+type VercelRequestContextReader = {
+  get?: () => VercelRequestContext | undefined;
+};
+
+/**
+ * Best-effort: keep the current serverless invocation alive until the
+ * promise settles. No-op outside a request context or off Vercel.
+ */
+export function waitUntil(promise: Promise<unknown>): void {
+  try {
+    const reader = (globalThis as Record<symbol, unknown>)[
+      VERCEL_REQUEST_CONTEXT_SYMBOL
+    ] as VercelRequestContextReader | undefined;
+    reader?.get?.()?.waitUntil?.(promise);
+  } catch {
+    // Never let lifetime management break exporting itself.
+  }
+}


### PR DESCRIPTION
## 🎯 Changes

What changes are made in this PR? Is it a feature or a bug fix?

## ✅ Checklist

- [ ] I have followed the steps listed in the Contributing guide.
- [ ] If necessary, I have added documentation related to the changes made.
- [ ] If applicable, I have added or updated the tests related to the changes made.

## 🔒 Related Issues

Closes #

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect when serverless invocations stay alive and how export success is determined; behavior is best-effort and isolated to telemetry export paths with defensive error handling.
> 
> **Overview**
> Fixes **silent span loss on Vercel/serverless** by registering each OTLP export `fetch` with the platform **`waitUntil`** (via a new internal helper that reads Vercel’s request-context symbol, no extra dependency; **no-op** elsewhere), so the invocation isn’t frozen while telemetry is still in flight.
> 
> **Export reliability and visibility** improve: HTTP **non-2xx** ingest responses are now **export failures** (with truncated body in the error, `diag.error`, and success only after draining the body), network errors also emit `diag.error`, and **`RunBatchSpanProcessor`** logs when a run batch export callback reports non-success.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c6b1c086a344b2c53527b888f38e35e83c111f27. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->