### PR TITLE
fix(python): support immutable OpenTelemetry spans

### DIFF
--- a/packages/python/contextcompany/agno/exporter.py
+++ b/packages/python/contextcompany/agno/exporter.py
@@ -6,6 +6,7 @@ from typing import Sequence
 from opentelemetry.sdk.trace import ReadableSpan
 from opentelemetry.sdk.trace.export import SpanExporter, SpanExportResult
 from .._utils import _debug
+from ..otel.span_copy import copy_span_with_attributes
 
 
 class MetadataFixingExporter(SpanExporter):
@@ -25,6 +26,7 @@ class MetadataFixingExporter(SpanExporter):
     def export(self, spans: Sequence[ReadableSpan]) -> SpanExportResult:
         # Group spans by trace
         traces: dict[int, list[ReadableSpan]] = {}
+        attribute_updates: dict[int, dict[str, str]] = {}
         for span in spans:
             trace_id = span.context.trace_id
             if trace_id not in traces:
@@ -58,19 +60,26 @@ class MetadataFixingExporter(SpanExporter):
             # Apply to all spans in the trace
             if user_run_id or user_session_id:
                 for span in trace_spans:
-                    if hasattr(span, "_attributes"):
-                        if user_run_id:
-                            span._attributes["tcc.runId"] = user_run_id
-                        if user_session_id:
-                            span._attributes["tcc.sessionId"] = user_session_id
+                    updates = attribute_updates.setdefault(id(span), {})
+                    if user_run_id:
+                        updates["tcc.runId"] = user_run_id
+                    if user_session_id:
+                        updates["tcc.sessionId"] = user_session_id
 
                 if user_run_id:
                     _debug(f"Fixed runId for trace {trace_id}: {user_run_id}")
                 if user_session_id:
                     _debug(f"Fixed sessionId for trace {trace_id}: {user_session_id}")
 
-        _debug(f"Exporting {len(spans)} spans")
-        return self.wrapped_exporter.export(spans)
+        export_spans = [
+            copy_span_with_attributes(span, attribute_updates[id(span)])
+            if id(span) in attribute_updates
+            else span
+            for span in spans
+        ]
+
+        _debug(f"Exporting {len(export_spans)} spans")
+        return self.wrapped_exporter.export(export_spans)
 
     def shutdown(self) -> None:
         return self.wrapped_exporter.shutdown()

--- a/packages/python/contextcompany/langchain/exporter.py
+++ b/packages/python/contextcompany/langchain/exporter.py
@@ -36,7 +36,7 @@ class RunIdFixingExporter(SpanExporter):
             if user_run_id:
                 _debug(f"Fixing runId for trace {trace_id}: {user_run_id}")
                 for span in trace_spans:
-                    attribute_updates[id(span)] = {"tcc.runId": user_run_id}
+                    attribute_updates.setdefault(id(span), {})["tcc.runId"] = user_run_id
 
         export_spans = [
             copy_span_with_attributes(span, attribute_updates[id(span)])

--- a/packages/python/contextcompany/langchain/exporter.py
+++ b/packages/python/contextcompany/langchain/exporter.py
@@ -2,6 +2,7 @@ from typing import Sequence
 from opentelemetry.sdk.trace.export import SpanExporter, SpanExportResult
 from opentelemetry.sdk.trace import ReadableSpan
 from .._utils import _debug
+from ..otel.span_copy import copy_span_with_attributes
 
 
 class RunIdFixingExporter(SpanExporter):
@@ -12,6 +13,7 @@ class RunIdFixingExporter(SpanExporter):
 
     def export(self, spans: Sequence[ReadableSpan]) -> SpanExportResult:
         traces = {}
+        attribute_updates: dict[int, dict[str, str]] = {}
         for span in spans:
             trace_id = span.context.trace_id
             if trace_id not in traces:
@@ -34,11 +36,17 @@ class RunIdFixingExporter(SpanExporter):
             if user_run_id:
                 _debug(f"Fixing runId for trace {trace_id}: {user_run_id}")
                 for span in trace_spans:
-                    if hasattr(span, '_attributes'):
-                        span._attributes["tcc.runId"] = user_run_id
+                    attribute_updates[id(span)] = {"tcc.runId": user_run_id}
 
-        _debug(f"Exporting {len(spans)} spans")
-        return self.wrapped_exporter.export(spans)
+        export_spans = [
+            copy_span_with_attributes(span, attribute_updates[id(span)])
+            if id(span) in attribute_updates
+            else span
+            for span in spans
+        ]
+
+        _debug(f"Exporting {len(export_spans)} spans")
+        return self.wrapped_exporter.export(export_spans)
 
     def shutdown(self) -> None:
         return self.wrapped_exporter.shutdown()

--- a/packages/python/contextcompany/otel/span_copy.py
+++ b/packages/python/contextcompany/otel/span_copy.py
@@ -1,0 +1,37 @@
+"""Helpers for enriching completed OpenTelemetry spans before export."""
+
+from typing import Any, Mapping
+
+from opentelemetry.sdk.trace import ReadableSpan
+
+
+def copy_span_with_attributes(
+    span: ReadableSpan,
+    attributes: Mapping[str, Any],
+) -> ReadableSpan:
+    """Return an export-only copy of ``span`` with merged attributes.
+
+    OpenTelemetry 1.43 makes the SDK's attribute container immutable when a
+    span ends. Exporters receive completed ``ReadableSpan`` objects, so they
+    must not mutate ``span._attributes``. Constructing a new readable span
+    keeps the recorded span untouched while allowing export-time enrichment.
+    """
+
+    merged_attributes = dict(span.attributes or {})
+    merged_attributes.update(attributes)
+
+    return ReadableSpan(
+        name=span.name,
+        context=span.context,
+        parent=span.parent,
+        resource=span.resource,
+        attributes=merged_attributes,
+        events=span.events,
+        links=span.links,
+        kind=span.kind,
+        instrumentation_info=getattr(span, "_instrumentation_info", None),
+        status=span.status,
+        start_time=span.start_time,
+        end_time=span.end_time,
+        instrumentation_scope=span.instrumentation_scope,
+    )

--- a/packages/python/contextcompany/otel/span_copy.py
+++ b/packages/python/contextcompany/otel/span_copy.py
@@ -29,7 +29,6 @@ def copy_span_with_attributes(
         events=span.events,
         links=span.links,
         kind=span.kind,
-        instrumentation_info=getattr(span, "_instrumentation_info", None),
         status=span.status,
         start_time=span.start_time,
         end_time=span.end_time,

--- a/packages/python/tests/test_exporters.py
+++ b/packages/python/tests/test_exporters.py
@@ -1,0 +1,119 @@
+import json
+import unittest
+
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import ReadableSpan
+from opentelemetry.sdk.trace.export import SpanExporter, SpanExportResult
+from opentelemetry.trace import SpanContext, TraceFlags
+
+from contextcompany.agno.exporter import MetadataFixingExporter
+from contextcompany.langchain.exporter import RunIdFixingExporter
+
+
+class RecordingExporter(SpanExporter):
+    def __init__(self):
+        self.spans = []
+
+    def export(self, spans):
+        self.spans = list(spans)
+        return SpanExportResult.SUCCESS
+
+    def shutdown(self):
+        return None
+
+
+def make_span(*, trace_id, span_id, parent=None, attributes=None):
+    return ReadableSpan(
+        name=f"span-{span_id}",
+        context=SpanContext(
+            trace_id=trace_id,
+            span_id=span_id,
+            is_remote=False,
+            trace_flags=TraceFlags(TraceFlags.SAMPLED),
+        ),
+        parent=parent,
+        resource=Resource.create({}),
+        attributes=attributes or {},
+        start_time=1,
+        end_time=2,
+    )
+
+
+class MetadataFixingExporterTests(unittest.TestCase):
+    def test_promotes_agno_metadata_without_mutating_completed_spans(self):
+        trace_id = 1
+        root = make_span(
+            trace_id=trace_id,
+            span_id=10,
+            attributes={
+                "metadata": json.dumps(
+                    {
+                        "tcc.runId": "11111111-1111-4111-8111-111111111111",
+                        "tcc.sessionId": "session-123",
+                    }
+                )
+            },
+        )
+        child = make_span(
+            trace_id=trace_id,
+            span_id=11,
+            parent=root.context,
+            attributes={"existing": "value"},
+        )
+        wrapped = RecordingExporter()
+
+        result = MetadataFixingExporter(wrapped).export([child, root])
+
+        self.assertEqual(result, SpanExportResult.SUCCESS)
+        self.assertNotIn("tcc.runId", root.attributes)
+        self.assertNotIn("tcc.runId", child.attributes)
+        self.assertEqual(
+            wrapped.spans[0].attributes["tcc.runId"],
+            "11111111-1111-4111-8111-111111111111",
+        )
+        self.assertEqual(wrapped.spans[0].attributes["tcc.sessionId"], "session-123")
+        self.assertEqual(wrapped.spans[0].attributes["existing"], "value")
+        self.assertEqual(
+            wrapped.spans[1].attributes["tcc.runId"],
+            "11111111-1111-4111-8111-111111111111",
+        )
+
+    def test_promotes_openinference_session_id(self):
+        root = make_span(
+            trace_id=2,
+            span_id=20,
+            attributes={"session.id": "openinference-session"},
+        )
+        wrapped = RecordingExporter()
+
+        MetadataFixingExporter(wrapped).export([root])
+
+        self.assertNotIn("tcc.sessionId", root.attributes)
+        self.assertEqual(
+            wrapped.spans[0].attributes["tcc.sessionId"],
+            "openinference-session",
+        )
+
+
+class RunIdFixingExporterTests(unittest.TestCase):
+    def test_promotes_langchain_run_id_without_mutating_completed_spans(self):
+        run_id = "22222222-2222-4222-8222-222222222222"
+        root = make_span(
+            trace_id=3,
+            span_id=30,
+            attributes={"langsmith.metadata.tcc.runId": run_id},
+        )
+        child = make_span(trace_id=3, span_id=31, parent=root.context)
+        wrapped = RecordingExporter()
+
+        result = RunIdFixingExporter(wrapped).export([root, child])
+
+        self.assertEqual(result, SpanExportResult.SUCCESS)
+        self.assertNotIn("tcc.runId", root.attributes)
+        self.assertNotIn("tcc.runId", child.attributes)
+        self.assertEqual(wrapped.spans[0].attributes["tcc.runId"], run_id)
+        self.assertEqual(wrapped.spans[1].attributes["tcc.runId"], run_id)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 🎯 Changes

What changes are made in this PR? Is it a feature or a bug fix?

## ✅ Checklist

- [ ] I have followed the steps listed in the Contributing guide.
- [ ] If necessary, I have added documentation related to the changes made.
- [ ] If applicable, I have added or updated the tests related to the changes made.

## 🔒 Related Issues

Closes #

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped export-path change with tests; behavior for downstream OTLP should match prior enrichment without touching in-memory span records.
> 
> **Overview**
> Fixes **Agno** and **LangChain** trace exporters so they still promote `tcc.runId` / `tcc.sessionId` when OpenTelemetry **1.43+** leaves completed spans’ attributes immutable.
> 
> Instead of writing to `span._attributes`, exporters collect per-span updates and pass **`copy_span_with_attributes`** copies to the wrapped exporter, leaving the recorded spans unchanged while export payloads stay enriched.
> 
> Adds shared helper **`packages/python/contextcompany/otel/span_copy.py`** and **`test_exporters.py`** tests that assert metadata/run-id promotion on exported spans without mutating the originals.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb52bcb532ab69ba2220d4217d7946efdd9b8abe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->