### PR TITLE
Prepare LangChain and OpenClaw packages for discovery

### DIFF
--- a/.changeset/calm-lions-trace.md
+++ b/.changeset/calm-lions-trace.md
@@ -1,0 +1,5 @@
+---
+"@contextcompany/langchain": patch
+---
+
+Install the shared API runtime dependency with the LangChain package.

--- a/.changeset/warm-owls-observe.md
+++ b/.changeset/warm-owls-observe.md
@@ -1,5 +1,5 @@
 ---
-"@contextcompany/openclaw": minor
+"@contextcompany/openclaw": major
 ---
 
 Support current OpenClaw hooks and ClawHub package contracts.

--- a/.changeset/warm-owls-observe.md
+++ b/.changeset/warm-owls-observe.md
@@ -1,0 +1,5 @@
+---
+"@contextcompany/openclaw": minor
+---
+
+Support current OpenClaw hooks and ClawHub package contracts.

--- a/examples/openclaw/README.md
+++ b/examples/openclaw/README.md
@@ -13,10 +13,13 @@ Then add to your `~/.openclaw/openclaw.json`:
 ```json5
 {
   "plugins": {
-    "allow": ["@contextcompany/openclaw"],
+    "allow": ["openclaw"],
     "entries": {
-      "@contextcompany/openclaw": {
+      "openclaw": {
         "enabled": true,
+        "hooks": {
+          "allowConversationAccess": true
+        },
         "config": {
           "apiKey": "${TCC_API_KEY}",
           "sessionId": "my-session-123",
@@ -30,6 +33,8 @@ Then add to your `~/.openclaw/openclaw.json`:
   }
 }
 ```
+
+OpenClaw requires `allowConversationAccess` before a non-bundled plugin can observe LLM input, output, and agent lifecycle events.
 
 Restart the gateway:
 

--- a/examples/openclaw/openclaw.json
+++ b/examples/openclaw/openclaw.json
@@ -1,9 +1,12 @@
 {
   "plugins": {
-    "allow": ["@contextcompany/openclaw"],
+    "allow": ["openclaw"],
     "entries": {
-      "@contextcompany/openclaw": {
+      "openclaw": {
         "enabled": true,
+        "hooks": {
+          "allowConversationAccess": true
+        },
         "config": {
           "apiKey": "${TCC_API_KEY}",
           "sessionId": "my-session-123",

--- a/packages/ts/langchain/package.json
+++ b/packages/ts/langchain/package.json
@@ -50,8 +50,10 @@
   "peerDependencies": {
     "@langchain/core": ">=0.2.0"
   },
+  "dependencies": {
+    "@contextcompany/api": "workspace:*"
+  },
   "devDependencies": {
-    "@contextcompany/api": "workspace:*",
     "@langchain/core": "^0.3.80",
     "@types/node": "^20.19.37",
     "tsup": "^8.5.1",

--- a/packages/ts/openclaw/README.md
+++ b/packages/ts/openclaw/README.md
@@ -1,6 +1,6 @@
 # @contextcompany/openclaw
 
-The Context Company observability plugin for [OpenClaw](https://openclaw.ai).
+[The Context Company](https://www.thecontextcompany.com) observability plugin for [OpenClaw](https://openclaw.ai).
 
 Captures LLM calls, tool executions, and agent lifecycle events from OpenClaw's plugin hook system, then exports them to The Context Company for visualization and analysis.
 
@@ -19,10 +19,13 @@ Add to your `openclaw.json`:
 ```json
 {
   "plugins": {
-    "allow": ["@contextcompany/openclaw"],
+    "allow": ["openclaw"],
     "entries": {
-      "@contextcompany/openclaw": {
+      "openclaw": {
         "enabled": true,
+        "hooks": {
+          "allowConversationAccess": true
+        },
         "config": {
           "apiKey": "${TCC_API_KEY}"
         }
@@ -31,6 +34,8 @@ Add to your `openclaw.json`:
   }
 }
 ```
+
+`allowConversationAccess` lets the plugin observe the prompts and responses needed to build complete traces. OpenClaw requires this explicit permission for non-bundled plugins.
 
 ### 3. Restart
 
@@ -90,12 +95,12 @@ handle.setMetadata({ userId: "u_abc", environment: "staging" });
 
 | Option | Env Var | Default | Description |
 |--------|---------|---------|-------------|
-| `apiKey` | `TCC_API_KEY` | — | Your Context Company API key |
+| `apiKey` | `TCC_API_KEY` | Not set | Your Context Company API key |
 | `endpoint` | `TCC_URL` | Auto-detected from key | Ingestion endpoint URL |
 | `debug` | `TCC_DEBUG` | `false` | Enable debug logging |
-| `runId` | — | Random UUID | Explicit run ID for the first run |
-| `sessionId` | — | — | Session ID to group related runs |
-| `metadata` | — | — | Key-value metadata attached to runs |
+| `runId` | Not set | Random UUID | Explicit run ID for the first run |
+| `sessionId` | Not set | Not set | Session ID to group related runs |
+| `metadata` | Not set | Not set | Key-value metadata attached to runs |
 
 ## How It Works
 
@@ -103,10 +108,10 @@ The plugin hooks into OpenClaw's agent lifecycle events:
 
 | Hook | What it captures |
 |------|-----------------|
-| `llm_input` | LLM call start — model, prompt, system prompt, history |
-| `llm_output` | LLM call end — response, token usage, cost |
-| `before_tool_call` | Tool execution start — tool name, arguments |
-| `after_tool_call` | Tool execution end — result, errors, duration |
-| `agent_end` | Run complete — success/failure, full message history |
+| `llm_input` | LLM call start: model, prompt, system prompt, history |
+| `llm_output` | LLM call end: response, token usage, cost |
+| `before_tool_call` | Tool execution start: tool name, arguments |
+| `after_tool_call` | Tool execution end: result, errors, duration |
+| `agent_end` | Run complete: success or failure, full message history |
 
 All events are collected during the agent run and sent as a single batch when the run completes. Sessions that never receive an `agent_end` are flushed after 30 minutes.

--- a/packages/ts/openclaw/openclaw.plugin.json
+++ b/packages/ts/openclaw/openclaw.plugin.json
@@ -1,7 +1,10 @@
 {
   "id": "openclaw",
   "name": "The Context Company",
-  "description": "Agent observability — captures LLM calls, tool executions, and agent lifecycle events",
+  "description": "AI agent observability that finds patterns in production and helps teams improve their agents",
+  "activation": {
+    "onStartup": true
+  },
   "configSchema": {
     "type": "object",
     "additionalProperties": false,

--- a/packages/ts/openclaw/package.json
+++ b/packages/ts/openclaw/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contextcompany/openclaw",
   "version": "1.1.4",
-  "description": "The Context Company integration for OpenClaw",
+  "description": "AI agent observability that finds patterns in production and helps teams improve their agents",
   "type": "module",
   "files": [
     "dist",
@@ -11,9 +11,24 @@
   ],
   "openclaw": {
     "extensions": [
-      "dist/index.cjs"
+      "dist/index.js"
     ],
-    "plugin": "openclaw.plugin.json"
+    "install": {
+      "clawhubSpec": "clawhub:@contextcompany/openclaw",
+      "npmSpec": "@contextcompany/openclaw",
+      "defaultChoice": "clawhub",
+      "minHostVersion": ">=2026.7.1"
+    },
+    "compat": {
+      "pluginApi": ">=2026.7.1"
+    },
+    "build": {
+      "openclawVersion": "2026.7.1"
+    },
+    "release": {
+      "publishToClawHub": true,
+      "publishToNpm": true
+    }
   },
   "main": "dist/index.cjs",
   "module": "dist/index.js",
@@ -53,10 +68,12 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.22.3 <23 || >=24.15.0 <25 || >=25.9.0"
+  },
+  "dependencies": {
+    "@contextcompany/api": "workspace:*"
   },
   "devDependencies": {
-    "@contextcompany/api": "workspace:*",
     "@types/node": "^20",
     "tsup": "^8.5.0",
     "typescript": "^5.9.3"

--- a/packages/ts/openclaw/src/plugin.ts
+++ b/packages/ts/openclaw/src/plugin.ts
@@ -1,10 +1,10 @@
 /**
- * @contextcompany/openclaw — OpenClaw plugin for The Context Company
+ * @contextcompany/openclaw: OpenClaw plugin for The Context Company
  *
  * Thin forwarder: collects raw hook events during an agent run,
  * then sends them all as one batch on agent_end.
  *
- * Per-session state is keyed by ctx.sessionKey — safe under concurrent
+ * Per-session state is keyed by ctx.sessionKey, so it is safe under concurrent
  * runs (e.g. multiple Slack threads served by the same gateway).
  *
  * All parsing/transformation happens server-side.
@@ -98,7 +98,7 @@ function registerHooks(
   configOverrides?: OpenClawPluginConfig,
 ): OpenClawHandle {
   const activeSessions = new Map<string, ActiveSession>();
-  // Per-session pending overrides applied at the next before_agent_start.
+  // Per-session pending overrides applied at the next before_prompt_build.
   const pendingOverrides = new Map<
     string,
     { runId?: string; sessionId?: string; metadata?: Record<string, string> }
@@ -155,7 +155,7 @@ function registerHooks(
   const onRunEnd = pluginConfig.onRunEnd;
 
   // -------------------------------------------------------------------
-  // Stale session cleanup — flush sessions that never got an agent_end
+  // Stale session cleanup: flush sessions that never got an agent_end
   // -------------------------------------------------------------------
   const STALE_SESSION_MS = 30 * 60 * 1000; // 30 minutes
 
@@ -230,7 +230,7 @@ function registerHooks(
 
     // sessionId resolution order:
     //   1. user config `sessionId` (static or function)
-    //   2. ctx.sessionKey — OpenClaw's internal session key, which is
+    //   2. ctx.sessionKey, OpenClaw's internal session key, which is
     //      thread-scoped for channel integrations with threads enabled
     //      (verified via live data: Slack threads in the same channel get
     //      distinct sessionKeys).
@@ -280,14 +280,15 @@ function registerHooks(
   // Hooks
   // -------------------------------------------------------------------
 
-  api.on("before_agent_start", async (event: any, ctx: any) => {
+  api.on("before_prompt_build", async (event: any, ctx: any) => {
     const runCtx = toRunContext(ctx);
     const sessionKey = runCtx.sessionKey;
     if (!sessionKey) return;
 
     const session = ensureSession(sessionKey, runCtx);
 
-    if (onRunStart) {
+    if (onRunStart && !session.onRunStartCalled) {
+      session.onRunStartCalled = true;
       const mutators = {
         setRunId: (id: string) => {
           session.runId = id;
@@ -368,7 +369,7 @@ function registerHooks(
 
       if (debug)
         log.info(
-          `agent_end — sending ${session.events.length} events (runId: ${session.runId})`,
+          `agent_end: sending ${session.events.length} events (runId: ${session.runId})`,
         );
 
       const payload = buildPayload(session, false);
@@ -432,14 +433,14 @@ function registerHooks(
 }
 
 /**
- * Full OpenClaw plugin object — install via `openclaw plugins install`
+ * Full OpenClaw plugin object. Install via `openclaw plugins install`.
  * and configure in `openclaw.json` under `plugins.entries`.
  */
 const plugin = {
   id: "openclaw",
   name: "The Context Company",
   description:
-    "Agent observability — captures LLM calls, tool executions, and agent lifecycle events",
+    "AI agent observability that finds patterns in production and helps teams improve their agents",
   register(api: any) {
     registerHooks(api);
   },

--- a/packages/ts/openclaw/src/types.ts
+++ b/packages/ts/openclaw/src/types.ts
@@ -24,6 +24,7 @@ export type ActiveSession = {
   sessionId?: string;
   metadata: Record<string, string>;
   turnCacheRunId?: string;
+  onRunStartCalled?: boolean;
 };
 
 /** Mutation API passed into onRunStart. Changes apply to this run only. */
@@ -36,7 +37,7 @@ export type OpenClawRunMutators = {
   setMetadata: (meta: Record<string, string>) => void;
 };
 
-/** Called at before_agent_start with the run context and mutation API. */
+/** Called at before_prompt_build with the run context and mutation API. */
 export type OpenClawRunStartHandler = (info: {
   runId: string;
   ctx: OpenClawRunContext;
@@ -79,7 +80,7 @@ export type OpenClawPluginConfig = {
   /** Default metadata merged into every run. */
   metadata?: OpenClawDefaultMetadata;
 
-  /** Called at before_agent_start; lets you override runId/sessionId/metadata per run. */
+  /** Called at before_prompt_build; lets you override runId/sessionId/metadata per run. */
   onRunStart?: OpenClawRunStartHandler;
   /** Called at agent_end; lets you attach feedback / log the runId. */
   onRunEnd?: OpenClawRunEndHandler;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -350,10 +350,11 @@ importers:
         version: 5.9.3
 
   packages/ts/langchain:
-    devDependencies:
+    dependencies:
       '@contextcompany/api':
         specifier: workspace:*
         version: link:../api
+    devDependencies:
       '@langchain/core':
         specifier: ^0.3.80
         version: 0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.220.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.9.0(@opentelemetry/api@1.9.1))(openai@6.26.0(ws@8.18.3)(zod@4.1.13))
@@ -411,10 +412,11 @@ importers:
         version: 3.25.76
 
   packages/ts/openclaw:
-    devDependencies:
+    dependencies:
       '@contextcompany/api':
         specifier: workspace:*
         version: link:../api
+    devDependencies:
       '@types/node':
         specifier: ^20
         version: 20.19.37


### PR DESCRIPTION
## What this changes

- ships `@contextcompany/api` with the LangChain and OpenClaw packages
- updates the OpenClaw plugin to the current hook and package contracts
- adds the metadata ClawHub needs to validate and publish the plugin
- documents OpenClaw's required conversation-access permission

## Verification

- built the API, LangChain, and OpenClaw packages on Node.js 22.22.3
- installed the packed LangChain package in a clean TypeScript project
- installed the packed OpenClaw package in a clean OpenClaw 2026.7.1 host
- passed ClawHub package validation with all six hooks detected

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> OpenClaw is a breaking major (hook rename and config key changes); misconfigured upgrades could miss traces until hosts use the new hook and conversation-access flag.
> 
> **Overview**
> **LangChain** and **OpenClaw** now declare `@contextcompany/api` as a **runtime dependency** (not only dev), so consumers get the shared API helpers when they install those packages.
> 
> **OpenClaw** is updated for current host and ClawHub contracts: `package.json` adds install/compat/build/release metadata, points the bundled extension at `dist/index.js`, tightens **Node** engine ranges, and sets **`onStartup`** activation in `openclaw.plugin.json`. The plugin registers **`before_prompt_build`** instead of **`before_agent_start`**, and **`onRunStart`** runs at most once per session via **`onRunStartCalled`**.
> 
> Docs and examples switch plugin config keys from `@contextcompany/openclaw` to **`openclaw`** and document **`hooks.allowConversationAccess`** for observing LLM and lifecycle events. Changesets: patch for LangChain, **major** for OpenClaw.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a37095bfb0f5597da5f9d512de2e8c1c0cb11a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->